### PR TITLE
Continuum trap lifetimes

### DIFF
--- a/arctic/__init__.py
+++ b/arctic/__init__.py
@@ -5,5 +5,6 @@ from arctic.traps import (
     TrapNonUniformDistribution,
     TrapManager,
     TrapManagerNonUniformDistribution,
+    TrapManagerTrackTime,
 )
 from arctic import util

--- a/arctic/__init__.py
+++ b/arctic/__init__.py
@@ -3,6 +3,7 @@ from arctic.model import ArcticParams, CCDVolume, CCDVolumeComplex
 from arctic.traps import (
     Trap,
     TrapNonUniformHeightDistribution,
+    TrapLifetimeContinuum,
     TrapManager,
     TrapManagerNonUniformHeightDistribution,
     TrapManagerTrackTime,

--- a/arctic/__init__.py
+++ b/arctic/__init__.py
@@ -2,9 +2,9 @@ from arctic.clock import Clocker
 from arctic.model import ArcticParams, CCDVolume, CCDVolumeComplex
 from arctic.traps import (
     Trap,
-    TrapNonUniformDistribution,
+    TrapNonUniformHeightDistribution,
     TrapManager,
-    TrapManagerNonUniformDistribution,
+    TrapManagerNonUniformHeightDistribution,
     TrapManagerTrackTime,
 )
 from arctic import util

--- a/arctic/clock.py
+++ b/arctic/clock.py
@@ -148,8 +148,7 @@ class Clocker(object):
         return express_multiplier
 
     def _add_cti_to_image(
-        self, image, sequence, phase_widths, traps, ccd_volume, express, 
-        initial_phase
+        self, image, sequence, phase_widths, traps, ccd_volume, express, initial_phase
     ):
         """
         Add CTI trails to an image by trapping, releasing, and moving electrons 
@@ -205,7 +204,7 @@ class Clocker(object):
         phases = len(sequence)
         assert len(phase_widths) == phases
         assert np.amax(phase_widths) <= 1
-        
+
         # Assume the same CCD volume for all phases if not otherwise specified
         if len(ccd_volume) == 1 and len(ccd_volume) != phases:
             ccd_volume *= phases
@@ -224,7 +223,7 @@ class Clocker(object):
             new_image[initial_phase::phases] = image
             image = new_image
             rows, columns = image.shape
-            
+
             express_matrix = np.repeat(express_matrix, phases, axis=1)
 
         # Set up the array of trap managers
@@ -232,9 +231,7 @@ class Clocker(object):
         for trap_group in traps:
             if type(traps) is TrapNonUniformHeightDistribution:
                 trap_managers.append(
-                    TrapManagerNonUniformHeightDistribution(
-                        traps=trap_group, rows=rows
-                    )
+                    TrapManagerNonUniformHeightDistribution(traps=trap_group, rows=rows)
                 )
             else:
                 trap_managers.append(TrapManager(traps=trap_group, rows=rows))
@@ -252,9 +249,7 @@ class Clocker(object):
                 # Each pixel
                 for row_index in range(rows):
                     phase = row_index % phases
-                    express_multiplier = express_matrix[
-                        express_index, row_index
-                    ]
+                    express_multiplier = express_matrix[express_index, row_index]
                     if express_multiplier == 0:
                         continue
 
@@ -266,8 +261,7 @@ class Clocker(object):
                     electrons_released = 0
                     for trap_manager in trap_managers:
                         electrons_released += trap_manager.electrons_released_in_pixel(
-                            time=sequence[phase], 
-                            width=phase_widths[phase]
+                            time=sequence[phase], width=phase_widths[phase]
                         )
                     electrons_available += electrons_released
 
@@ -276,7 +270,7 @@ class Clocker(object):
                     for trap_manager in trap_managers:
                         electrons_captured += trap_manager.electrons_captured_in_pixel(
                             electrons_available=electrons_available,
-                            ccd_volume=ccd_volume[phase], 
+                            ccd_volume=ccd_volume[phase],
                             width=phase_widths[phase],
                         )
 
@@ -289,9 +283,7 @@ class Clocker(object):
 
         # Recombine the image for multi-phase clocking
         if phases != 1:
-            image = image.reshape((int(rows / phases), phases, columns)).sum(
-                axis=1
-            )
+            image = image.reshape((int(rows / phases), phases, columns)).sum(axis=1)
 
         return image
 

--- a/arctic/clock.py
+++ b/arctic/clock.py
@@ -8,9 +8,9 @@ import numpy as np
 from copy import deepcopy
 
 from arctic.traps import (
-    TrapNonUniformDistribution,
+    TrapNonUniformHeightDistribution,
     TrapManager,
-    TrapManagerNonUniformDistribution,
+    TrapManagerNonUniformHeightDistribution,
 )
 
 
@@ -230,9 +230,9 @@ class Clocker(object):
         # Set up the array of trap managers
         trap_managers = []
         for trap_group in traps:
-            if type(traps) is TrapNonUniformDistribution:
+            if type(traps) is TrapNonUniformHeightDistribution:
                 trap_managers.append(
-                    TrapManagerNonUniformDistribution(
+                    TrapManagerNonUniformHeightDistribution(
                         traps=trap_group, rows=rows
                     )
                 )

--- a/arctic/traps.py
+++ b/arctic/traps.py
@@ -208,6 +208,35 @@ class TrapLifetimeContinuum(Trap):
         self.middle_lifetime = middle_lifetime
         self.scale_lifetime = scale_lifetime
 
+    def electrons_released_from_time_elapsed_and_time(self, time_elapsed, time=1):
+        """ Calculate the number of released electrons from the trap.
+
+            Parameters
+            ----------
+            time_elapsed : float
+                The time elapsed since capture.
+            time : float
+                The time spent in this pixel or phase, in the same units as the 
+                trap lifetime.
+
+            Returns
+            -------
+            electrons_released : float
+                The number of released electrons.
+        """
+        def integrand(lifetime, time_elapsed, time, mean, scale):
+            return (
+                self.distribution_of_traps_with_lifetime(lifetime, mean, scale)
+                * np.exp(-time_elapsed / lifetime)
+                * (1 - np.exp(-time / lifetime))
+            )
+
+        return integrate.quad(
+            integrand, 0, np.inf, args=(
+                time_elapsed, time, self.middle_lifetime, self.scale_lifetime
+            )
+        )[0]
+
 
 class TrapManager(object):
     def __init__(self, traps, rows):

--- a/arctic/traps.py
+++ b/arctic/traps.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from scipy import integrate
 
 
@@ -171,6 +170,43 @@ class TrapNonUniformHeightDistribution(Trap):
 
         self.electron_fractional_height_min = electron_fractional_height_min
         self.electron_fractional_height_max = electron_fractional_height_max
+
+
+class TrapLifetimeContinuum(Trap):
+    """ For a continuum distribution of release lifetimes for the traps.
+        Must be used with TrapManagerTrackTime.
+    """
+    
+    def __init__(
+        self,
+        density,
+        distribution_of_traps_with_lifetime,
+        middle_lifetime=None,
+        scale_lifetime=None,
+    ):
+        """The parameters for a single trap species.
+
+        Parameters
+        ----------
+        density : float
+            The density of the trap species in a pixel.
+        distribution_of_traps_with_lifetime : func
+            The distribution of traps as a function of lifetime, middle lifetime, 
+            and lifetime scale, such that its integral from 0 to infinity = 1.
+            e.g. a log-normal probability density function.
+        middle_lifetime : float
+            The middle (e.g. mean or median depending on the distribution) 
+            release lifetime of the trap.
+        scale_lifetime : float
+            The scale of release lifetimes of the trap.
+        """
+        super(TrapLifetimeContinuum, self).__init__(
+            density=density, lifetime=middle_lifetime
+        )
+
+        self.distribution_of_traps_with_lifetime = distribution_of_traps_with_lifetime
+        self.middle_lifetime = middle_lifetime
+        self.scale_lifetime = scale_lifetime
 
 
 class TrapManager(object):
@@ -1050,3 +1086,4 @@ class TrapManagerTrackTime(TrapManager):
             ]
 
         return watermarks
+

--- a/arctic/traps.py
+++ b/arctic/traps.py
@@ -1115,17 +1115,30 @@ class TrapManagerTrackTime(TrapManager):
 
             # Edit the new watermarks' times to correspond to the original fill
             # fraction plus (1 - original fill) * enough.
-            # e.g. enough = 0.5 --> time equivalent of fill half way to full.
+            # e.g. enough = 0.5 --> time equivalent of fill half way to full.            
             # Awkwardly need to convert to fill fractions first using each 
             # trap's lifetime separately, but can still do all levels at once.
-            watermarks[: watermark_index_above_height + 1, 1:] = np.transpose([
-                trap.time_elapsed_from_fill_fraction(
-                    trap.fill_fraction_from_time_elapsed(time) * (1 - enough) + enough
-                )
-                for trap, time in zip(
-                    self.traps, watermarks[: watermark_index_above_height + 1, 1:].T
-                )
-            ])
+            ### Actually can't do more than one at a time with continuum traps!
+            # watermarks[: watermark_index_above_height + 1, 1:] = np.transpose([
+            #     trap.time_elapsed_from_fill_fraction(
+            #         trap.fill_fraction_from_time_elapsed(time) * (1 - enough) + enough
+            #     )
+            #     for trap, time in zip(
+            #         self.traps, watermarks[: watermark_index_above_height + 1, 1:].T
+            #     )
+            # ])
+            
+            # Awkwardly need to convert to fill fractions first using each 
+            # trap's lifetime separately.
+            for watermark_index in range(watermark_index_above_height + 1):
+                watermarks[watermark_index, 1:] = [
+                    trap.time_elapsed_from_fill_fraction(
+                        trap.fill_fraction_from_time_elapsed(time) * (1 - enough) + enough
+                    )
+                    for trap, time in zip(
+                        self.traps, watermarks[watermark_index, 1:]
+                    )
+                ]
 
             # If all watermarks will be overwritten
             if cumulative_watermark_height[-1] < electron_fractional_height:

--- a/arctic/traps.py
+++ b/arctic/traps.py
@@ -121,7 +121,10 @@ class Trap(object):
         return poisson_trap
 
 
-class TrapNonUniformDistribution(Trap):
+class TrapNonUniformHeightDistribution(Trap):
+    """ For a non-uniform distribution of traps with height within the pixel.
+    """
+    
     def __init__(
         self,
         density,
@@ -129,20 +132,20 @@ class TrapNonUniformDistribution(Trap):
         electron_fractional_height_min,
         electron_fractional_height_max,
     ):
-        """The parameters for a single trap species 
+        """The parameters for a single trap species. 
 
         Parameters
         ----------
         density : float
             The trap density of the trap.
         lifetime : float
-            The trap lifetimes of the trap.
+            The release lifetime of the trap.
         electron_fractional_height_min, electron_fractional_height_max : float
             The minimum (maximum) fractional height of the electron cloud in 
             the pixel below (above) which corresponds to an effective fractional 
             height of 0 (1), with a linear relation in between.
         """
-        super(TrapNonUniformDistribution, self).__init__(
+        super(TrapNonUniformHeightDistribution, self).__init__(
             density=density, lifetime=lifetime
         )
 
@@ -558,7 +561,7 @@ class TrapManager(object):
         return electrons_captured
 
 
-class TrapManagerNonUniformDistribution(TrapManager):
+class TrapManagerNonUniformHeightDistribution(TrapManager):
     """ For a non-uniform distribution of traps with height within the pixel.
     """
 
@@ -581,7 +584,7 @@ class TrapManagerNonUniformDistribution(TrapManager):
             The number of rows in the image. i.e. the maximum number of
             possible electron trap/release events.
         """
-        super(TrapManagerNonUniformDistribution, self).__init__(traps=traps, rows=rows)
+        super(TrapManagerNonUniformHeightDistribution, self).__init__(traps=traps, rows=rows)
 
         self.electron_fractional_height_min = traps[0].electron_fractional_height_min
         self.electron_fractional_height_max = traps[0].electron_fractional_height_max

--- a/arctic/traps.py
+++ b/arctic/traps.py
@@ -17,7 +17,7 @@ class Trap(object):
         self.density = density
         self.lifetime = lifetime
 
-    def fill_fraction_from_time(self, time):
+    def fill_fraction_from_time_elapsed(self, time):
         """ Calculate the fraction of filled traps after a certain time.
 
             Parameters
@@ -33,7 +33,7 @@ class Trap(object):
         """
         return np.exp(-time / self.lifetime)
 
-    def time_from_fill_fraction(self, fill):
+    def time_elapsed_from_fill_fraction(self, fill):
         """ Calculate the total time elapsed from the fraction of filled traps.
 
             Parameters
@@ -64,7 +64,7 @@ class Trap(object):
             electrons_released : float
                 The number of released electrons.
         """
-        return electrons * (1 - self.fill_fraction_from_time(time))
+        return electrons * (1 - self.fill_fraction_from_time_elapsed(time))
 
     def electrons_released_from_time_elapsed_and_time(self, time_elapsed, time=1):
         """ Calculate the number of released electrons from the trap.
@@ -902,7 +902,7 @@ class TrapManagerTrackTime(TrapManager):
             # Fill fractions from elapsed times
             fill_fractions = np.array(
                 [
-                    trap.fill_fraction_from_time(time)
+                    trap.fill_fraction_from_time_elapsed(time)
                     for trap, time in zip(traps, watermarks[watermark_index, 1:])
                 ]
             )
@@ -1039,7 +1039,7 @@ class TrapManagerTrackTime(TrapManager):
         if max_watermark_index == 0:
             # Edit the new watermark
             watermarks[0, 0] = electron_fractional_height
-            watermarks[0, 1:] = [trap.time_from_fill_fraction(enough) for trap in self.traps]
+            watermarks[0, 1:] = [trap.time_elapsed_from_fill_fraction(enough) for trap in self.traps]
 
             return watermarks
 
@@ -1074,8 +1074,8 @@ class TrapManagerTrackTime(TrapManager):
             # Awkwardly need to convert to fill fractions first using each 
             # trap's lifetime separately, but can still do all levels at once.
             watermarks[: watermark_index_above_height + 1, 1:] = np.transpose([
-                trap.time_from_fill_fraction(
-                    trap.fill_fraction_from_time(time) * (1 - enough) + enough
+                trap.time_elapsed_from_fill_fraction(
+                    trap.fill_fraction_from_time_elapsed(time) * (1 - enough) + enough
                 )
                 for trap, time in zip(
                     self.traps, watermarks[: watermark_index_above_height + 1, 1:].T
@@ -1089,7 +1089,7 @@ class TrapManagerTrackTime(TrapManager):
                     electron_fractional_height - cumulative_watermark_height[-1]
                 )
                 watermarks[watermark_index_above_height + 1, 1:] = [
-                    trap.time_from_fill_fraction(enough) for trap in self.traps
+                    trap.time_elapsed_from_fill_fraction(enough) for trap in self.traps
                 ]
             else:
                 # Edit the new watermarks' heights
@@ -1108,8 +1108,8 @@ class TrapManagerTrackTime(TrapManager):
             # Edit the new first watermark
             watermarks[0, 0] = electron_fractional_height
             watermarks[0, 1:] = [
-                trap.time_from_fill_fraction(
-                    trap.fill_fraction_from_time(time) * (1 - enough) + enough
+                trap.time_elapsed_from_fill_fraction(
+                    trap.fill_fraction_from_time_elapsed(time) * (1 - enough) + enough
                 )
                 for trap, time in zip(self.traps, watermarks[1, 1:])
             ]

--- a/test_arctic/unit/test_clock.py
+++ b/test_arctic/unit/test_clock.py
@@ -162,7 +162,7 @@ class TestClocker:
         traps = [
             [ac.Trap(density=10, lifetime=-1 / np.log(0.5))],
             [
-                ac.TrapNonUniformDistribution(
+                ac.TrapNonUniformHeightDistribution(
                     density=5,
                     lifetime=-1 / np.log(0.5),
                     electron_fractional_height_min=0,

--- a/test_arctic/unit/test_clock.py
+++ b/test_arctic/unit/test_clock.py
@@ -70,9 +70,7 @@ class TestClocker:
             abs=1e-3,
         )
 
-    def test__remove_cti__parallel_only__single_pixel__successive_iterations(
-        self,
-    ):
+    def test__remove_cti__parallel_only__single_pixel__successive_iterations(self,):
         image = np.zeros((6, 2))
         image[2, 1] = 1000
 
@@ -1096,7 +1094,7 @@ class TestAddCTIParallelMultiPhase:
         )
 
         clocker = ac.Clocker(
-            parallel_sequence=[0.5, 0.2, 0.2, 0.1], 
+            parallel_sequence=[0.5, 0.2, 0.2, 0.1],
             parallel_phase_widths=[0.5, 0.2, 0.2, 0.1],
         )
 
@@ -1115,7 +1113,7 @@ class TestAddCTIParallelMultiPhase:
         assert (
             image_difference[3:-1, :] > 0.0
         ).all()  # All other pixels should have charge trailed into them
-    
+
 
 class TestArcticCorrectCTIParallelOnly:
     def test__square__horizontal_line__corrected_image_more_like_original(self):

--- a/test_arctic/unit/test_clock.py
+++ b/test_arctic/unit/test_clock.py
@@ -70,7 +70,7 @@ class TestClocker:
             abs=1e-3,
         )
 
-    def test__remove_cti__parallel_only__single_pixel__compare_to_cplusplus_version(
+    def test__remove_cti__parallel_only__single_pixel__successive_iterations(
         self,
     ):
         image = np.zeros((6, 2))

--- a/test_arctic/unit/test_model.py
+++ b/test_arctic/unit/test_model.py
@@ -5,23 +5,23 @@ import arctic as ac
 
 
 class TestSpecies:
-    def test__electrons_released_from_electrons(self):
+    def test__electrons_released_from_electrons_and_time(self):
 
         trap = ac.Trap(lifetime=1.0)
 
-        assert trap.electrons_released_from_electrons(
+        assert trap.electrons_released_from_electrons_and_time(
             electrons=1.0
         ) == pytest.approx(0.6321, 1.0e-4)
-        assert trap.electrons_released_from_electrons(
+        assert trap.electrons_released_from_electrons_and_time(
             electrons=2.0
         ) == pytest.approx(2.0 * 0.6321, 1.0e-4)
 
         trap = ac.Trap(lifetime=2.0)
 
-        assert trap.electrons_released_from_electrons(
+        assert trap.electrons_released_from_electrons_and_time(
             electrons=1.0
         ) == pytest.approx(0.39346, 1.0e-4)
-        assert trap.electrons_released_from_electrons(
+        assert trap.electrons_released_from_electrons_and_time(
             electrons=2.0
         ) == pytest.approx(2.0 * 0.39346, 1.0e-4)
 

--- a/test_arctic/unit/test_model.py
+++ b/test_arctic/unit/test_model.py
@@ -29,9 +29,7 @@ class TestSpecies:
 
         trap = ac.Trap(density=0.5, lifetime=2.0)
 
-        assert trap.delta_ellipticity == pytest.approx(
-            0.047378295117617694, 1.0e-5
-        )
+        assert trap.delta_ellipticity == pytest.approx(0.047378295117617694, 1.0e-5)
 
     def test__delta_ellipticity_of_arctic_params(self):
 
@@ -43,21 +41,16 @@ class TestSpecies:
         parameters = ac.ArcticParams(parallel_traps=[parallel_1_trap])
         assert parameters.delta_ellipticity == parallel_1_trap.delta_ellipticity
 
-        parameters = ac.ArcticParams(
-            parallel_traps=[parallel_1_trap, parallel_2_trap]
-        )
+        parameters = ac.ArcticParams(parallel_traps=[parallel_1_trap, parallel_2_trap])
         assert (
             parameters.delta_ellipticity
-            == parallel_1_trap.delta_ellipticity
-            + parallel_2_trap.delta_ellipticity
+            == parallel_1_trap.delta_ellipticity + parallel_2_trap.delta_ellipticity
         )
 
         parameters = ac.ArcticParams(serial_traps=[serial_1_trap])
         assert parameters.delta_ellipticity == serial_1_trap.delta_ellipticity
 
-        parameters = ac.ArcticParams(
-            serial_traps=[serial_1_trap, serial_2_trap]
-        )
+        parameters = ac.ArcticParams(serial_traps=[serial_1_trap, serial_2_trap])
         assert (
             parameters.delta_ellipticity
             == serial_1_trap.delta_ellipticity + serial_2_trap.delta_ellipticity
@@ -84,10 +77,7 @@ class TestParallelDensityVary:
 
         parallel_vary = ac.Trap.poisson_trap(
             trap=list(
-                map(
-                    lambda density: ac.Trap(density=density, lifetime=1.0),
-                    (0.1,),
-                )
+                map(lambda density: ac.Trap(density=density, lifetime=1.0), (0.1,),)
             ),
             shape=(1000, 1),
             seed=1,
@@ -100,10 +90,7 @@ class TestParallelDensityVary:
     ):
         parallel_vary = ac.Trap.poisson_trap(
             trap=list(
-                map(
-                    lambda density: ac.Trap(density=density, lifetime=1.0),
-                    (1.0,),
-                )
+                map(lambda density: ac.Trap(density=density, lifetime=1.0), (1.0,),)
             ),
             shape=(1000, 1),
             seed=1,
@@ -114,10 +101,7 @@ class TestParallelDensityVary:
     def test__1_trap__density_1___2_row_pixels__poisson_value_is_near_1(self):
         parallel_vary = ac.Trap.poisson_trap(
             trap=list(
-                map(
-                    lambda density: ac.Trap(density=density, lifetime=1.0),
-                    (1.0,),
-                )
+                map(lambda density: ac.Trap(density=density, lifetime=1.0), (1.0,),)
             ),
             shape=(1000, 2),
             seed=1,
@@ -128,10 +112,7 @@ class TestParallelDensityVary:
     def test__2_trap__1_row_pixel__poisson_for_each_trap_drawn(self):
         parallel_vary = ac.Trap.poisson_trap(
             trap=list(
-                map(
-                    lambda density: ac.Trap(density=density, lifetime=1.0),
-                    (1.0, 2.0),
-                )
+                map(lambda density: ac.Trap(density=density, lifetime=1.0), (1.0, 2.0),)
             ),
             shape=(1000, 1),
             seed=1,
@@ -142,10 +123,7 @@ class TestParallelDensityVary:
     def test__2_trap__2_row_pixel__poisson_for_each_trap_drawn(self):
         parallel_vary = ac.Trap.poisson_trap(
             trap=list(
-                map(
-                    lambda density: ac.Trap(density=density, lifetime=1.0),
-                    (1.0, 2.0),
-                )
+                map(lambda density: ac.Trap(density=density, lifetime=1.0), (1.0, 2.0),)
             ),
             shape=(1000, 2),
             seed=1,
@@ -184,9 +162,7 @@ class TestParallelDensityVary:
 
 
 class TestCCDVolume:
-    def test__eletron_fractional_height_from_electrons__gives_correct_value(
-        self,
-    ):
+    def test__eletron_fractional_height_from_electrons__gives_correct_value(self,):
 
         parallel_ccd_volume = ac.CCDVolume(
             well_max_height=10000.0, well_notch_depth=0.0, well_fill_beta=1.0
@@ -244,9 +220,7 @@ class TestCCDVolume:
 
 
 class TestCCDVolumeComplex:
-    def test__eletron_fractional_height_from_electrons__gives_correct_value(
-        self,
-    ):
+    def test__eletron_fractional_height_from_electrons__gives_correct_value(self,):
 
         parallel_ccd_volume = ac.CCDVolumeComplex(
             well_max_height=15.0,

--- a/test_arctic/unit/test_traps.py
+++ b/test_arctic/unit/test_traps.py
@@ -109,17 +109,17 @@ class TestElectronsReleasedAndUpdatedWatermarks:
         )
 
     def test__single_trap__change_width(self):
-    
+
         # Half the time, double the density --> same result
         traps = [ac.Trap(density=20, lifetime=-1 / np.log(0.5))]
         trap_manager = ac.TrapManager(traps=traps, rows=6)
-    
+
         trap_manager.watermarks = np.array(
             [[0.5, 0.8], [0.2, 0.4], [0.1, 0.2], [0, 0], [0, 0], [0, 0]]
         )
-    
+
         electrons_released = trap_manager.electrons_released_in_pixel(width=0.5)
-    
+
         assert electrons_released == pytest.approx(2.5)
         assert trap_manager.watermarks == pytest.approx(
             np.array([[0.5, 0.4], [0.2, 0.2], [0.1, 0.1], [0, 0], [0, 0], [0, 0]])
@@ -684,3 +684,29 @@ class TestTrapManagerNonUniformDistribution:
         )
 
         assert electrons_captured == pytest.approx((0.96 * 0.2 + 0.01 * 0.6) * 10)
+
+
+class TestTimeAndFillFraction:
+    def test__fill_fraction_from_time_or_fill_fraction(self):
+
+        trap = ac.Trap(density=10, lifetime=2)
+
+        fill = trap.fill_fraction_from_time(1)
+        assert fill == np.exp(-0.5)
+
+        time = trap.time_from_fill_fraction(0.5)
+        assert time == -2 * np.log(0.5)
+
+        assert fill == trap.fill_fraction_from_time(trap.time_from_fill_fraction(fill))
+        assert time == trap.time_from_fill_fraction(trap.fill_fraction_from_time(time))
+
+    def test__electrons_released_from_electrons_and_time_or_fill_fraction(self):
+
+        trap = ac.Trap(density=10, lifetime=2)
+        electrons = 1e3
+        time = 1
+        fill = trap.fill_fraction_from_time(time)
+
+        assert trap.electrons_released_from_electrons_and_time(
+            electrons, time
+        ) == trap.electrons_released_from_electrons_and_fill_fraction(electrons, fill)

--- a/test_arctic/unit/test_traps.py
+++ b/test_arctic/unit/test_traps.py
@@ -700,13 +700,27 @@ class TestTimeAndFillFraction:
         assert fill == trap.fill_fraction_from_time(trap.time_from_fill_fraction(fill))
         assert time == trap.time_from_fill_fraction(trap.fill_fraction_from_time(time))
 
-    def test__electrons_released_from_electrons_and_time_or_fill_fraction(self):
+    def test__electrons_released_in_pixel_time_or_fill(self):
 
-        trap = ac.Trap(density=10, lifetime=2)
-        electrons = 1e3
-        time = 1
-        fill = trap.fill_fraction_from_time(time)
+        trap = ac.Trap(density=10, lifetime=-1 / np.log(0.5))
+        trap_manager_fill = ac.TrapManager(traps=[trap], rows=6)
+        trap_manager_time = ac.TrapManagerTrackTime(traps=[trap], rows=6)
 
-        assert trap.electrons_released_from_electrons_and_time(
-            electrons, time
-        ) == trap.electrons_released_from_electrons_and_fill_fraction(electrons, fill)
+        trap_manager_fill.watermarks = np.array(
+            [[0.5, 0.8], [0.2, 0.4], [0.1, 0.2], [0, 0], [0, 0], [0, 0]]
+        )
+        trap_manager_time.watermarks = np.array(
+            [
+                [0.5, trap.time_from_fill_fraction(0.8)],
+                [0.2, trap.time_from_fill_fraction(0.4)],
+                [0.1, trap.time_from_fill_fraction(0.2)],
+                [0, 0],
+                [0, 0],
+                [0, 0],
+            ]
+        )
+
+        electrons_released_fill = trap_manager_fill.electrons_released_in_pixel()
+        electrons_released_time = trap_manager_time.electrons_released_in_pixel()
+
+        assert electrons_released_fill == electrons_released_time

--- a/test_arctic/unit/test_traps.py
+++ b/test_arctic/unit/test_traps.py
@@ -857,9 +857,77 @@ class TestTrapLifetimeContinuum:
                 trap.middle_lifetime, trap.scale_lifetime
             )
         )[0] == pytest.approx(1)
-        
-    def test__electrons_released_from_time_elapsed_and_time_narrow_continuum(self):
 
+    def test__fill_fraction_from_time_elapsed_narrow_continuum(self):
+
+        # Check that narrow distribution gives similar result to single lifetime  
+        # Simple trap
+        trap = ac.Trap(density=10, lifetime=1)
+        fill_single = trap.fill_fraction_from_time_elapsed(1)
+        
+        # Narrow continuum
+        median_lifetime = 1
+        scale_lifetime = 0.1
+        def trap_distribution(lifetime, median, scale):
+            return np.exp(-(np.log(lifetime) - np.log(median))**2 / (2 * scale**2)) / (
+                lifetime * scale * np.sqrt(2*np.pi)
+            )
+        trap = ac.TrapLifetimeContinuum(
+            density=10, 
+            distribution_of_traps_with_lifetime=trap_distribution,
+            middle_lifetime=median_lifetime,
+            scale_lifetime=scale_lifetime,
+        )
+        fill_continuum = trap.fill_fraction_from_time_elapsed(1)
+        
+        assert fill_continuum == pytest.approx(fill_single, rel=0.01)
+
+    def test__time_elapsed_from_fill_fraction_narrow_continuum(self):
+
+        # Check that narrow distribution gives similar result to single lifetime  
+        # Simple trap
+        trap = ac.Trap(density=10, lifetime=1)
+        time_single = trap.time_elapsed_from_fill_fraction(0.5)
+        
+        # Narrow continuum
+        median_lifetime = 1
+        scale_lifetime = 0.1
+        def trap_distribution(lifetime, median, scale):
+            return np.exp(-(np.log(lifetime) - np.log(median))**2 / (2 * scale**2)) / (
+                lifetime * scale * np.sqrt(2*np.pi)
+            )
+        trap = ac.TrapLifetimeContinuum(
+            density=10, 
+            distribution_of_traps_with_lifetime=trap_distribution,
+            middle_lifetime=median_lifetime,
+            scale_lifetime=scale_lifetime,
+        )
+        time_continuum = trap.time_elapsed_from_fill_fraction(0.5)
+        
+        assert time_continuum == pytest.approx(time_single, rel=0.01)
+        
+    def test__time_elapsed_from_fill_fraction_continuum(self):
+        
+        median_lifetime = 1
+        scale_lifetime = 1
+        def trap_distribution(lifetime, median, scale):
+            return np.exp(-(np.log(lifetime) - np.log(median))**2 / (2 * scale**2)) / (
+                lifetime * scale * np.sqrt(2*np.pi)
+            )
+        trap = ac.TrapLifetimeContinuum(
+            density=10, 
+            distribution_of_traps_with_lifetime=trap_distribution,
+            middle_lifetime=median_lifetime,
+            scale_lifetime=scale_lifetime,
+        )
+        time = 1
+        
+        assert trap.time_elapsed_from_fill_fraction(
+            trap.fill_fraction_from_time_elapsed(time)
+        ) == time
+       
+    def test__electrons_released_from_time_elapsed_and_time_narrow_continuum(self):
+    
         # Check that narrow distribution gives similar result to single lifetime  
         # Simple trap
         trap = ac.Trap(density=10, lifetime=1)
@@ -868,7 +936,7 @@ class TestTrapLifetimeContinuum:
             [[0.5, 0.8], [0.2, 0.4], [0.1, 0.2], [0, 0], [0, 0], [0, 0]]
         )
         electrons_released_single = trap_manager.electrons_released_in_pixel()
-        
+    
         # Narrow continuum
         median_lifetime = 1
         scale_lifetime = 0.1
@@ -894,13 +962,13 @@ class TestTrapLifetimeContinuum:
             ]
         )        
         electrons_released_continuum = trap_manager.electrons_released_in_pixel()
-        
+    
         assert electrons_released_continuum == pytest.approx(
             electrons_released_single, rel=0.01
         )
-        
+    
     def test__electrons_released_from_time_elapsed_and_time_continuum(self):
-
+    
         # Check that distribution gives somewhat similar result to single lifetime  
         # Simple trap
         trap = ac.Trap(density=10, lifetime=1)
@@ -909,7 +977,7 @@ class TestTrapLifetimeContinuum:
             [[0.5, 0.8], [0.2, 0.4], [0.1, 0.2], [0, 0], [0, 0], [0, 0]]
         )
         electrons_released_single = trap_manager.electrons_released_in_pixel()
-        
+    
         # Continuum
         median_lifetime = 1
         scale_lifetime = 1
@@ -935,7 +1003,8 @@ class TestTrapLifetimeContinuum:
             ]
         )        
         electrons_released_continuum = trap_manager.electrons_released_in_pixel()
-        
+    
         assert electrons_released_continuum == pytest.approx(
-            electrons_released_single, rel=0.5
+            electrons_released_single, rel=1
         )
+    

--- a/test_arctic/unit/test_traps.py
+++ b/test_arctic/unit/test_traps.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from scipy import integrate
 
 import arctic as ac
 
@@ -831,3 +832,28 @@ class TestTrapManagerTrackTime:
                 ]
             )
         )
+
+
+class TestTrapLifetimeContinuum:
+    def test__distribution_of_traps_with_lifetime(self):
+        
+        median_lifetime = 1
+        scale_lifetime = 0.5
+        def trap_distribution(lifetime, median, scale):
+            return np.exp(-(np.log(lifetime) - np.log(median))**2 / (2 * scale**2)) / (
+                lifetime * scale * np.sqrt(2*np.pi)
+            )
+
+        trap = ac.TrapLifetimeContinuum(
+            density=10, 
+            distribution_of_traps_with_lifetime=trap_distribution,
+            middle_lifetime=median_lifetime,
+            scale_lifetime=scale_lifetime,
+        )
+                
+        # Test integral from zero to infinity is one
+        assert pytest.approx(integrate.quad(
+            trap.distribution_of_traps_with_lifetime, 0, np.inf, args=(
+                trap.middle_lifetime, trap.scale_lifetime
+            )
+        )[0]) == 1

--- a/test_arctic/unit/test_traps.py
+++ b/test_arctic/unit/test_traps.py
@@ -688,18 +688,18 @@ class TestTrapManagerNonUniformHeightDistribution:
 
 
 class TestTrapManagerTrackTime:
-    def test__fill_fraction_from_time_or_fill_fraction(self):
+    def test__fill_fraction_from_time_elapsed(self):
 
         trap = ac.Trap(density=10, lifetime=2)
 
-        fill = trap.fill_fraction_from_time(1)
+        fill = trap.fill_fraction_from_time_elapsed(1)
         assert fill == np.exp(-0.5)
 
-        time = trap.time_from_fill_fraction(0.5)
+        time = trap.time_elapsed_from_fill_fraction(0.5)
         assert time == -2 * np.log(0.5)
 
-        assert fill == trap.fill_fraction_from_time(trap.time_from_fill_fraction(fill))
-        assert time == trap.time_from_fill_fraction(trap.fill_fraction_from_time(time))
+        assert fill == trap.fill_fraction_from_time_elapsed(trap.time_elapsed_from_fill_fraction(fill))
+        assert time == trap.time_elapsed_from_fill_fraction(trap.fill_fraction_from_time_elapsed(time))
 
     def test__electrons_released_in_pixel_using_time(self):
 
@@ -712,9 +712,9 @@ class TestTrapManagerTrackTime:
         )
         trap_manager_time.watermarks = np.array(
             [
-                [0.5, trap.time_from_fill_fraction(0.8)],
-                [0.2, trap.time_from_fill_fraction(0.4)],
-                [0.1, trap.time_from_fill_fraction(0.2)],
+                [0.5, trap.time_elapsed_from_fill_fraction(0.8)],
+                [0.2, trap.time_elapsed_from_fill_fraction(0.4)],
+                [0.1, trap.time_elapsed_from_fill_fraction(0.2)],
                 [0, 0],
                 [0, 0],
                 [0, 0],
@@ -737,9 +737,9 @@ class TestTrapManagerTrackTime:
         )
         trap_manager_time.watermarks = np.array(
             [
-                [0.5, trap.time_from_fill_fraction(0.8)],
-                [0.2, trap.time_from_fill_fraction(0.4)],
-                [0.1, trap.time_from_fill_fraction(0.3)],
+                [0.5, trap.time_elapsed_from_fill_fraction(0.8)],
+                [0.2, trap.time_elapsed_from_fill_fraction(0.4)],
+                [0.1, trap.time_elapsed_from_fill_fraction(0.3)],
                 [0, 0],
                 [0, 0],
                 [0, 0],
@@ -767,9 +767,9 @@ class TestTrapManagerTrackTime:
 
         watermarks = np.array(
             [
-                [0.5, trap.time_from_fill_fraction(0.8)],
-                [0.2, trap.time_from_fill_fraction(0.4)],
-                [0.1, trap.time_from_fill_fraction(0.3)],
+                [0.5, trap.time_elapsed_from_fill_fraction(0.8)],
+                [0.2, trap.time_elapsed_from_fill_fraction(0.4)],
+                [0.1, trap.time_elapsed_from_fill_fraction(0.3)],
                 [0, 0],
                 [0, 0],
                 [0, 0],
@@ -786,7 +786,7 @@ class TestTrapManagerTrackTime:
             np.array(
                 [
                     [0.75, 0],
-                    [0.05, trap.time_from_fill_fraction(0.3)],
+                    [0.05, trap.time_elapsed_from_fill_fraction(0.3)],
                     [0, 0],
                     [0, 0],
                     [0, 0],
@@ -803,9 +803,9 @@ class TestTrapManagerTrackTime:
 
         watermarks = np.array(
             [
-                [0.5, trap_1.time_from_fill_fraction(0.8), trap_2.time_from_fill_fraction(0.6)],
-                [0.2, trap_1.time_from_fill_fraction(0.4), trap_2.time_from_fill_fraction(0.2)],
-                [0.1, trap_1.time_from_fill_fraction(0.3), trap_2.time_from_fill_fraction(0.1)],
+                [0.5, trap_1.time_elapsed_from_fill_fraction(0.8), trap_2.time_elapsed_from_fill_fraction(0.6)],
+                [0.2, trap_1.time_elapsed_from_fill_fraction(0.4), trap_2.time_elapsed_from_fill_fraction(0.2)],
+                [0.1, trap_1.time_elapsed_from_fill_fraction(0.3), trap_2.time_elapsed_from_fill_fraction(0.1)],
                 [0, 0, 0],
                 [0, 0, 0],
                 [0, 0, 0],
@@ -823,10 +823,10 @@ class TestTrapManagerTrackTime:
         assert watermarks == pytest.approx(
             np.array(
                 [
-                    [0.5, trap_1.time_from_fill_fraction(0.9), trap_2.time_from_fill_fraction(0.8)], 
-                    [0.1, trap_1.time_from_fill_fraction(0.7), trap_2.time_from_fill_fraction(0.6)], 
-                    [0.1, trap_1.time_from_fill_fraction(0.4), trap_2.time_from_fill_fraction(0.2)], 
-                    [0.1, trap_1.time_from_fill_fraction(0.3), trap_2.time_from_fill_fraction(0.1)], 
+                    [0.5, trap_1.time_elapsed_from_fill_fraction(0.9), trap_2.time_elapsed_from_fill_fraction(0.8)], 
+                    [0.1, trap_1.time_elapsed_from_fill_fraction(0.7), trap_2.time_elapsed_from_fill_fraction(0.6)], 
+                    [0.1, trap_1.time_elapsed_from_fill_fraction(0.4), trap_2.time_elapsed_from_fill_fraction(0.2)], 
+                    [0.1, trap_1.time_elapsed_from_fill_fraction(0.3), trap_2.time_elapsed_from_fill_fraction(0.1)], 
                     [0, 0, 0], 
                     [0, 0, 0]
                 ]
@@ -885,9 +885,9 @@ class TestTrapLifetimeContinuum:
         trap_manager = ac.TrapManagerTrackTime(traps=[trap], rows=6)
         trap_manager.watermarks = np.array(
             [
-                [0.5, trap.time_from_fill_fraction(0.8)],
-                [0.2, trap.time_from_fill_fraction(0.4)],
-                [0.1, trap.time_from_fill_fraction(0.2)],
+                [0.5, trap.time_elapsed_from_fill_fraction(0.8)],
+                [0.2, trap.time_elapsed_from_fill_fraction(0.4)],
+                [0.1, trap.time_elapsed_from_fill_fraction(0.2)],
                 [0, 0],
                 [0, 0],
                 [0, 0],
@@ -926,9 +926,9 @@ class TestTrapLifetimeContinuum:
         trap_manager = ac.TrapManagerTrackTime(traps=[trap], rows=6)
         trap_manager.watermarks = np.array(
             [
-                [0.5, trap.time_from_fill_fraction(0.8)],
-                [0.2, trap.time_from_fill_fraction(0.4)],
-                [0.1, trap.time_from_fill_fraction(0.2)],
+                [0.5, trap.time_elapsed_from_fill_fraction(0.8)],
+                [0.2, trap.time_elapsed_from_fill_fraction(0.4)],
+                [0.1, trap.time_elapsed_from_fill_fraction(0.2)],
                 [0, 0],
                 [0, 0],
                 [0, 0],

--- a/test_arctic/unit/test_traps.py
+++ b/test_arctic/unit/test_traps.py
@@ -725,6 +725,17 @@ class TestTrapManagerTrackTime:
         electrons_released_time = trap_manager_time.electrons_released_in_pixel()
 
         assert electrons_released_fill == electrons_released_time
+        
+        assert trap_manager_time.watermarks == pytest.approx(
+            [
+                [0.5, trap.time_elapsed_from_fill_fraction(0.4)],
+                [0.2, trap.time_elapsed_from_fill_fraction(0.2)],
+                [0.1, trap.time_elapsed_from_fill_fraction(0.1)],
+                [0, 0],
+                [0, 0],
+                [0, 0],
+            ]
+        )
 
     def test__electrons_captured_by_traps_using_time(self):
 
@@ -1109,4 +1120,57 @@ class TestTrapLifetimeContinuum:
         assert electrons_captured_single == pytest.approx(
             electrons_captured_continuum, rel=1
         )
+
+    def test__updated_watermarks_from_capture_narrow_continuum(self):
     
+        # Check that narrow continuum gives similar results to single lifetime  
+        # Simple trap
+        trap = ac.Trap(density=10, lifetime=-1 / np.log(0.5))
+        trap_manager = ac.TrapManagerTrackTime(traps=[trap], rows=6)
+        watermarks = np.array(
+            [
+                [0.5, trap.time_elapsed_from_fill_fraction(0.8)],
+                [0.2, trap.time_elapsed_from_fill_fraction(0.4)],
+                [0.1, trap.time_elapsed_from_fill_fraction(0.3)],
+                [0, 0],
+                [0, 0],
+                [0, 0],
+            ]
+        )
+        electron_fractional_height = 0.75
+        watermarks_single = trap_manager.updated_watermarks_from_capture(
+            electron_fractional_height=electron_fractional_height,
+            watermarks=watermarks
+        ) 
+    
+        # Narrow continuum
+        median_lifetime = 1
+        scale_lifetime = 0.1
+        def trap_distribution(lifetime, median, scale):
+            return np.exp(-(np.log(lifetime) - np.log(median))**2 / (2 * scale**2)) / (
+                lifetime * scale * np.sqrt(2*np.pi)
+            )
+        trap = ac.TrapLifetimeContinuum(
+            density=10, 
+            distribution_of_traps_with_lifetime=trap_distribution,
+            middle_lifetime=median_lifetime,
+            scale_lifetime=scale_lifetime,
+        )        
+        trap_manager = ac.TrapManagerTrackTime(traps=[trap], rows=6)
+        watermarks = np.array(
+            [
+                [0.5, trap.time_elapsed_from_fill_fraction(0.8)],
+                [0.2, trap.time_elapsed_from_fill_fraction(0.4)],
+                [0.1, trap.time_elapsed_from_fill_fraction(0.2)],
+                [0, 0],
+                [0, 0],
+                [0, 0],
+            ]
+        )
+        electron_fractional_height = 0.75
+        watermarks_continuum = trap_manager.updated_watermarks_from_capture(
+            electron_fractional_height=electron_fractional_height,
+            watermarks=watermarks
+        )
+        
+        assert watermarks_continuum == pytest.approx(watermarks_single, rel=0.1)

--- a/test_arctic/unit/test_traps.py
+++ b/test_arctic/unit/test_traps.py
@@ -860,7 +860,7 @@ class TestTrapLifetimeContinuum:
 
     def test__fill_fraction_from_time_elapsed_narrow_continuum(self):
 
-        # Check that narrow distribution gives similar result to single lifetime  
+        # Check that narrow continuum gives similar results to single lifetime  
         # Simple trap
         trap = ac.Trap(density=10, lifetime=1)
         fill_single = trap.fill_fraction_from_time_elapsed(1)
@@ -884,7 +884,7 @@ class TestTrapLifetimeContinuum:
 
     def test__time_elapsed_from_fill_fraction_narrow_continuum(self):
 
-        # Check that narrow distribution gives similar result to single lifetime  
+        # Check that narrow continuum gives similar results to single lifetime  
         # Simple trap
         trap = ac.Trap(density=10, lifetime=1)
         time_single = trap.time_elapsed_from_fill_fraction(0.5)
@@ -928,7 +928,7 @@ class TestTrapLifetimeContinuum:
        
     def test__electrons_released_from_time_elapsed_and_time_narrow_continuum(self):
     
-        # Check that narrow distribution gives similar result to single lifetime  
+        # Check that narrow continuum gives similar results to single lifetime  
         # Simple trap
         trap = ac.Trap(density=10, lifetime=1)
         trap_manager = ac.TrapManager(traps=[trap], rows=6)
@@ -969,7 +969,7 @@ class TestTrapLifetimeContinuum:
     
     def test__electrons_released_from_time_elapsed_and_time_continuum(self):
     
-        # Check that distribution gives somewhat similar result to single lifetime  
+        # Check that continuum gives somewhat similar results to single lifetime  
         # Simple trap
         trap = ac.Trap(density=10, lifetime=1)
         trap_manager = ac.TrapManager(traps=[trap], rows=6)
@@ -1006,5 +1006,107 @@ class TestTrapLifetimeContinuum:
     
         assert electrons_released_continuum == pytest.approx(
             electrons_released_single, rel=1
+        )
+
+    def test__electrons_captured_by_traps_narrow_continuum(self):
+            
+        # Check that narrow continuum gives similar results to single lifetime  
+        # Simple trap
+        trap = ac.Trap(density=10, lifetime=1)
+        trap_manager = ac.TrapManager(traps=[trap], rows=6)
+        trap_manager.watermarks = np.array(
+            [[0.5, 0.8], [0.2, 0.4], [0.1, 0.2], [0, 0], [0, 0], [0, 0]]
+        )
+        electron_fractional_height = 0.6
+        electrons_captured_single = trap_manager.electrons_captured_by_traps(
+            electron_fractional_height=electron_fractional_height,
+            watermarks=trap_manager.watermarks,
+            traps=trap_manager.traps,
+        )
+    
+        # Narrow continuum
+        median_lifetime = 1
+        scale_lifetime = 0.1
+        def trap_distribution(lifetime, median, scale):
+            return np.exp(-(np.log(lifetime) - np.log(median))**2 / (2 * scale**2)) / (
+                lifetime * scale * np.sqrt(2*np.pi)
+            )
+        trap = ac.TrapLifetimeContinuum(
+            density=10, 
+            distribution_of_traps_with_lifetime=trap_distribution,
+            middle_lifetime=median_lifetime,
+            scale_lifetime=scale_lifetime,
+        )        
+        trap_manager = ac.TrapManagerTrackTime(traps=[trap], rows=6)
+        trap_manager.watermarks = np.array(
+            [
+                [0.5, trap.time_elapsed_from_fill_fraction(0.8)],
+                [0.2, trap.time_elapsed_from_fill_fraction(0.4)],
+                [0.1, trap.time_elapsed_from_fill_fraction(0.2)],
+                [0, 0],
+                [0, 0],
+                [0, 0],
+            ]
+        )
+        electron_fractional_height = 0.6
+        electrons_captured_continuum = trap_manager.electrons_captured_by_traps(
+            electron_fractional_height=electron_fractional_height,
+            watermarks=trap_manager.watermarks,
+            traps=trap_manager.traps,
+        )
+
+        assert electrons_captured_continuum == pytest.approx(
+            electrons_captured_single, rel=0.01
+        )
+    
+    def test__electrons_captured_by_traps_continuum(self):
+            
+        # Check that continuum gives somewhat similar results to single lifetime 
+        # Simple trap
+        trap = ac.Trap(density=10, lifetime=1)
+        trap_manager = ac.TrapManager(traps=[trap], rows=6)
+        trap_manager.watermarks = np.array(
+            [[0.5, 0.8], [0.2, 0.4], [0.1, 0.2], [0, 0], [0, 0], [0, 0]]
+        )
+        electron_fractional_height = 0.6
+        electrons_captured_single = trap_manager.electrons_captured_by_traps(
+            electron_fractional_height=electron_fractional_height,
+            watermarks=trap_manager.watermarks,
+            traps=trap_manager.traps,
+        )
+    
+        # Narrow continuum
+        median_lifetime = 1
+        scale_lifetime = 1
+        def trap_distribution(lifetime, median, scale):
+            return np.exp(-(np.log(lifetime) - np.log(median))**2 / (2 * scale**2)) / (
+                lifetime * scale * np.sqrt(2*np.pi)
+            )
+        trap = ac.TrapLifetimeContinuum(
+            density=10, 
+            distribution_of_traps_with_lifetime=trap_distribution,
+            middle_lifetime=median_lifetime,
+            scale_lifetime=scale_lifetime,
+        )        
+        trap_manager = ac.TrapManagerTrackTime(traps=[trap], rows=6)
+        trap_manager.watermarks = np.array(
+            [
+                [0.5, trap.time_elapsed_from_fill_fraction(0.8)],
+                [0.2, trap.time_elapsed_from_fill_fraction(0.4)],
+                [0.1, trap.time_elapsed_from_fill_fraction(0.2)],
+                [0, 0],
+                [0, 0],
+                [0, 0],
+            ]
+        )
+        electron_fractional_height = 0.6
+        electrons_captured_continuum = trap_manager.electrons_captured_by_traps(
+            electron_fractional_height=electron_fractional_height,
+            watermarks=trap_manager.watermarks,
+            traps=trap_manager.traps,
+        )
+
+        assert electrons_captured_single == pytest.approx(
+            electrons_captured_continuum, rel=1
         )
     

--- a/test_arctic/unit/test_traps.py
+++ b/test_arctic/unit/test_traps.py
@@ -607,18 +607,18 @@ class TestElectronsCapturedInPixel:
         )
 
 
-class TestTrapManagerNonUniformDistribution:
+class TestTrapManagerNonUniformHeightDistribution:
     def test__effective_non_uniform_electron_fractional_height(self):
 
         traps = [
-            ac.TrapNonUniformDistribution(
+            ac.TrapNonUniformHeightDistribution(
                 density=10,
                 lifetime=-1 / np.log(0.5),
                 electron_fractional_height_min=0.95,
                 electron_fractional_height_max=1,
             )
         ]
-        trap_manager = ac.TrapManagerNonUniformDistribution(traps=traps, rows=6,)
+        trap_manager = ac.TrapManagerNonUniformHeightDistribution(traps=traps, rows=6,)
 
         assert trap_manager.effective_non_uniform_electron_fractional_height(0.9) == 0
         assert trap_manager.effective_non_uniform_electron_fractional_height(1) == 1
@@ -629,14 +629,14 @@ class TestTrapManagerNonUniformDistribution:
     def test__first_capture(self):
 
         traps = [
-            ac.TrapNonUniformDistribution(
+            ac.TrapNonUniformHeightDistribution(
                 density=10,
                 lifetime=-1 / np.log(0.5),
                 electron_fractional_height_min=0.95,
                 electron_fractional_height_max=1,
             )
         ]
-        trap_manager = ac.TrapManagerNonUniformDistribution(traps=traps, rows=6,)
+        trap_manager = ac.TrapManagerNonUniformHeightDistribution(traps=traps, rows=6,)
 
         electron_fractional_height = 0.5
 
@@ -648,7 +648,7 @@ class TestTrapManagerNonUniformDistribution:
 
         assert electrons_captured == pytest.approx(0.5 * 10)
 
-        trap_manager = ac.TrapManagerNonUniformDistribution(traps=traps, rows=6,)
+        trap_manager = ac.TrapManagerNonUniformHeightDistribution(traps=traps, rows=6,)
 
         electron_fractional_height = 0.99
 
@@ -663,14 +663,14 @@ class TestTrapManagerNonUniformDistribution:
     def test__middle_new_watermarks(self):
 
         traps = [
-            ac.TrapNonUniformDistribution(
+            ac.TrapNonUniformHeightDistribution(
                 density=10,
                 lifetime=-1 / np.log(0.5),
                 electron_fractional_height_min=0.95,
                 electron_fractional_height_max=1,
             )
         ]
-        trap_manager = ac.TrapManagerNonUniformDistribution(traps=traps, rows=6,)
+        trap_manager = ac.TrapManagerNonUniformHeightDistribution(traps=traps, rows=6,)
 
         trap_manager.watermarks = np.array(
             [[0.96, 0.8], [0.98, 0.4], [0.99, 0.3], [0, 0], [0, 0], [0, 0]]


### PR DESCRIPTION
Implement traps with a continuous distribution of lifetimes. 

Also the option to have watermarks track time-since-capture instead of fill-fractions for identical results for normal traps too.