### PR TITLE
Wellfill

### DIFF
--- a/arctic/ccd.py
+++ b/arctic/ccd.py
@@ -41,9 +41,10 @@ class CCD(object):
         Parameters
         ----------
         fraction_of_traps : float or [float]
-            For multi-phase clocking, the physical width of each phase. This is used only to
-            distribute the traps between phases (they are assigned to a phaae in proportional
-            to the width of that phase). The units do not matter and can be anything from
+            Assuming that traps have uniform density throughout the CCD, for multi-phase 
+            clocking, this specifies the physical width of each phase. This is used only to
+            distribute the traps between phases. The units do not matter and can be anything 
+            from
             microns to light years, or fractions of a pixel. Only the fractional widths are
             ever returned. If this is an array then you can optionally also enter a list of
             different full_well_depth, well_notch_depth, and well_fill_power for each phase.
@@ -274,40 +275,43 @@ class CCD(object):
 
 class CCDPhase(object):
     def __init__(self, ccd=CCD(), phase=0):
-        """Hello"""
+        """Extract just one phase from the CCD"""
 
         self.fraction_of_traps = ccd.fraction_of_traps[phase]
-
         self.full_well_depth = ccd.full_well_depth[phase]
         self.well_fill_power = ccd.well_fill_power[phase]
         self.well_notch_depth = ccd.well_notch_depth[phase]
         self.well_bloom_level = ccd.well_bloom_level[phase]
+        self.cloud_fractional_volume_from_n_electrons = ccd.cloud_fractional_volume_from_n_electrons_in_phase(phase)
 
-    def cloud_fractional_volume_from_n_electrons(self, n_electrons, surface=False):
-
-        fraction_of_traps = self.fraction_of_traps
-        full_well_depth = self.full_well_depth
-        well_fill_power = self.well_fill_power
-        well_notch_depth = self.well_notch_depth
-        well_bloom_level = self.well_bloom_level
-
-        if n_electrons == 0:
-            return 0
-
-        # print('surface?',surface)
-        if surface:
-            empty = self.blooming_level
-            beta = 1
-        else:
-            empty = self.well_notch_depth
-            beta = self.well_fill_power
-        well_range = self.full_well_depth - empty
-
-        volume = (util.set_min_max((n_electrons - empty) / well_range, 0, 1)) ** beta
-
-        # volume = ( n_electrons > 500 )
-
-        return volume
+#    def cloud_fractional_volume_from_n_electrons(self, phase=0):
+#        return ccd.cloud_fractional_volume_from_n_electrons_in_phase(phase)
+#    
+#    def OLD_cloud_fractional_volume_from_n_electrons(self, n_electrons, surface=False):
+#
+#        fraction_of_traps = self.fraction_of_traps
+#        full_well_depth = self.full_well_depth
+#        well_fill_power = self.well_fill_power
+#        well_notch_depth = self.well_notch_depth
+#        well_bloom_level = self.well_bloom_level
+#
+#        if n_electrons == 0:
+#            return 0
+#
+#        # print('surface?',surface)
+#        if surface:
+#            empty = self.blooming_level
+#            beta = 1
+#        else:
+#            empty = self.well_notch_depth
+#            beta = self.well_fill_power
+#        well_range = self.full_well_depth - empty
+#
+#        volume = (util.set_min_max((n_electrons - empty) / well_range, 0, 1)) ** beta
+#
+#        # volume = ( n_electrons > 500 )
+#
+#        return volume
 
 
 class CCDComplex(CCD):

--- a/arctic/ccd.py
+++ b/arctic/ccd.py
@@ -86,9 +86,10 @@ class CCD(object):
             self._fraction_of_traps = value
         else:
             self._fraction_of_traps = [value]  # Make sure the arrays are arrays
+        #Renormalise?
+        #self._pixel_width = sum( i for i in self._fraction_of_traps )
+        #self._fraction_of_traps = [i / self._pixel_width for i in self._fraction_of_traps]
         self._n_phases = len(self._fraction_of_traps)
-
-    #   self._pixel_width = sum( i for i in self._fraction_of_traps )
 
     @property
     def n_phases(self):
@@ -97,10 +98,6 @@ class CCD(object):
     # @property
     # def pixel_width(self):
     #    return self._pixel_width
-
-    # @property
-    # def phase_fractional_widths(self):
-    #    return [i / self._pixel_width for i in self._fraction_of_traps]
 
     @property
     def full_well_depth(self):
@@ -171,41 +168,6 @@ class CCD(object):
                 value = self.full_well_depth
             self._well_bloom_level = [value] * self.n_phases
 
-    def cumulative_n_traps_from_n_electrons(self, n_electrons):
-        #
-        # RJM: this is not currently used. But it could be....
-        #
-
-        well_depth = self.ccd.full_well_depth
-        if self.surface:
-            alpha = self.ccd.blooming_level
-            beta = 1
-            # Let surface traps soak up everything they can, as a cheap way of
-            # ensuring that (at least with instantaneous trapping), no pixel in
-            # an output image will ever contain more electrons than the full
-            # well depth.
-            extra_traps = min(n_electrons - well_depth, 0)
-        else:
-            alpha = self.ccd.well_notch_depth
-            beta = self.ccd.well_fill_power
-            extra_traps = 0
-
-        n_electrons_available = n_electrons - alpha
-        n_traps = (
-            self.density
-            * util.set_min_max((n_electrons_available) / (well_depth - alpha), 0, 1)
-            ** beta
-        )
-        n_traps += extra_traps
-
-        # Make sure that the effective number of traps available cannot exceed
-        # the number of electrons. Adjusting this here is algorithmically much
-        # easier than catching lots of excpetions when there are insufficient
-        # electrons to fill traps during the capture process.
-        n_traps = min(n_traps, n_electrons_available)
-
-        return n_traps
-
     # Returns a (self-contained) function describing the well-filling model in a single phase
     def cloud_fractional_volume_from_n_electrons_and_phase(
         self, n_electrons, phase=0, surface=False
@@ -268,9 +230,45 @@ class CCD(object):
             volume = (
                 util.set_min_max((n_electrons - empty) / well_range, 0, 1)
             ) ** beta
+            
             return volume
 
         return cloud_fractional_volume_from_n_electrons
+
+    def cumulative_n_traps_from_n_electrons(self, n_electrons):
+        #
+        # RJM: this is not currently used. But it could be....
+        #
+
+        well_depth = self.ccd.full_well_depth
+        if self.surface:
+            alpha = self.ccd.blooming_level
+            beta = 1
+            # Let surface traps soak up everything they can, as a cheap way of
+            # ensuring that (at least with instantaneous trapping), no pixel in
+            # an output image will ever contain more electrons than the full
+            # well depth.
+            extra_traps = min(n_electrons - well_depth, 0)
+        else:
+            alpha = self.ccd.well_notch_depth
+            beta = self.ccd.well_fill_power
+            extra_traps = 0
+
+        n_electrons_available = n_electrons - alpha
+        n_traps = (
+            self.density
+            * util.set_min_max((n_electrons_available) / (well_depth - alpha), 0, 1)
+            ** beta
+        )
+        n_traps += extra_traps
+
+        # Make sure that the effective number of traps available cannot exceed
+        # the number of electrons. Adjusting this here is algorithmically much
+        # easier than catching lots of excpetions when there are insufficient
+        # electrons to fill traps during the capture process.
+        n_traps = min(n_traps, n_electrons_available)
+
+        return n_traps
 
 
 class CCDPhase(object):
@@ -283,35 +281,6 @@ class CCDPhase(object):
         self.well_notch_depth = ccd.well_notch_depth[phase]
         self.well_bloom_level = ccd.well_bloom_level[phase]
         self.cloud_fractional_volume_from_n_electrons = ccd.cloud_fractional_volume_from_n_electrons_in_phase(phase)
-
-#    def cloud_fractional_volume_from_n_electrons(self, phase=0):
-#        return ccd.cloud_fractional_volume_from_n_electrons_in_phase(phase)
-#    
-#    def OLD_cloud_fractional_volume_from_n_electrons(self, n_electrons, surface=False):
-#
-#        fraction_of_traps = self.fraction_of_traps
-#        full_well_depth = self.full_well_depth
-#        well_fill_power = self.well_fill_power
-#        well_notch_depth = self.well_notch_depth
-#        well_bloom_level = self.well_bloom_level
-#
-#        if n_electrons == 0:
-#            return 0
-#
-#        # print('surface?',surface)
-#        if surface:
-#            empty = self.blooming_level
-#            beta = 1
-#        else:
-#            empty = self.well_notch_depth
-#            beta = self.well_fill_power
-#        well_range = self.full_well_depth - empty
-#
-#        volume = (util.set_min_max((n_electrons - empty) / well_range, 0, 1)) ** beta
-#
-#        # volume = ( n_electrons > 500 )
-#
-#        return volume
 
 
 class CCDComplex(CCD):
@@ -393,7 +362,7 @@ class CCDComplex(CCD):
                 (n_electrons - self.well_notch_depth)
                 / (
                     self.well_range - self.well_notch_depth
-                )  # RJM I think that is a bug because nothch depth has been subtracted twice
+                )  # RJM I think that is a bug because notch depth has been subtracted twice
             )
         ) ** self.well_fill_power
 

--- a/arctic/ccd.py
+++ b/arctic/ccd.py
@@ -86,9 +86,9 @@ class CCD(object):
             self._fraction_of_traps = value
         else:
             self._fraction_of_traps = [value]  # Make sure the arrays are arrays
-        #Renormalise?
-        #self._pixel_width = sum( i for i in self._fraction_of_traps )
-        #self._fraction_of_traps = [i / self._pixel_width for i in self._fraction_of_traps]
+        # Renormalise?
+        # self._pixel_width = sum( i for i in self._fraction_of_traps )
+        # self._fraction_of_traps = [i / self._pixel_width for i in self._fraction_of_traps]
         self._n_phases = len(self._fraction_of_traps)
 
     @property
@@ -230,7 +230,7 @@ class CCD(object):
             volume = (
                 util.set_min_max((n_electrons - empty) / well_range, 0, 1)
             ) ** beta
-            
+
             return volume
 
         return cloud_fractional_volume_from_n_electrons
@@ -280,7 +280,9 @@ class CCDPhase(object):
         self.well_fill_power = ccd.well_fill_power[phase]
         self.well_notch_depth = ccd.well_notch_depth[phase]
         self.well_bloom_level = ccd.well_bloom_level[phase]
-        self.cloud_fractional_volume_from_n_electrons = ccd.cloud_fractional_volume_from_n_electrons_in_phase(phase)
+        self.cloud_fractional_volume_from_n_electrons = ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+            phase
+        )
 
 
 class CCDComplex(CCD):

--- a/arctic/main.py
+++ b/arctic/main.py
@@ -68,12 +68,10 @@ def _clock_charge_in_one_direction(
 
     # Parse inputs
     n_rows_in_image, n_columns_in_image = image.shape
-    print(window_row, n_rows_in_image, range(n_rows_in_image))
     if window_row is None:
         window_row = range(n_rows_in_image)
     elif isinstance(window_row, int):
         window_row = [window_row]
-    print(window_row)
     if window_column is None:
         window_column = range(n_columns_in_image)
 
@@ -106,7 +104,6 @@ def _clock_charge_in_one_direction(
             ),
             axis=0,
         )
-
 
     # Read out one column of pixels through one (column of) traps
     for column_index in range(len(window_column)):

--- a/arctic/main.py
+++ b/arctic/main.py
@@ -135,9 +135,8 @@ def _clock_charge_in_one_direction(
                             + potential["capture_from_which_pixel"]
                         )
                         n_free_electrons = (
-                            (image[row_read, window_column[column_index]])
-                            * potential["high"]
-                        )
+                            image[row_read, window_column[column_index]]
+                        ) * potential["high"]
 
                         # Allow electrons to be released from and captured by charge traps
                         n_electrons_released_and_captured = 0
@@ -145,8 +144,9 @@ def _clock_charge_in_one_direction(
                             n_electrons_released_and_captured += trap_manager.n_electrons_released_and_captured(
                                 n_free_electrons=n_free_electrons,
                                 dwell_time=roe.dwell_times[clocking_step],
-                                ccd_filling_function = ccd.cloud_fractional_volume_from_n_electrons_in_phase(phase),
-                                #ccd=ccd, phase=phase, #CCDPhase(ccd, phase),
+                                ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                                    phase
+                                ),
                                 express_multiplier=express_multiplier,
                             )
 

--- a/arctic/main.py
+++ b/arctic/main.py
@@ -135,7 +135,7 @@ def _clock_charge_in_one_direction(
                             + potential["capture_from_which_pixel"]
                         )
                         n_free_electrons = (
-                            image[row_read, window_column[column_index]]
+                            (image[row_read, window_column[column_index]])
                             * potential["high"]
                         )
 
@@ -145,7 +145,8 @@ def _clock_charge_in_one_direction(
                             n_electrons_released_and_captured += trap_manager.n_electrons_released_and_captured(
                                 n_free_electrons=n_free_electrons,
                                 dwell_time=roe.dwell_times[clocking_step],
-                                ccd=CCDPhase(ccd, phase),
+                                ccd_filling_function = ccd.cloud_fractional_volume_from_n_electrons_in_phase(phase),
+                                #ccd=ccd, phase=phase, #CCDPhase(ccd, phase),
                                 express_multiplier=express_multiplier,
                             )
 

--- a/arctic/roe.py
+++ b/arctic/roe.py
@@ -206,9 +206,10 @@ class ROEAbstract(object):
             for phase in range(n_phases):
 
                 # Where to capture from?
-                capture_from_which_pixel = np.array(
-                    [(step_prime - phase + ((n_phases - 1) // 2)) // n_phases]
-                )
+                #capture_from_which_pixel = np.array(
+                #    [(step_prime - phase + ((n_phases - 1) // 2)) // n_phases]
+                #)
+                capture_from_which_pixel = (step_prime - phase + ((n_phases - 1) // 2)) // n_phases
 
                 # How many pixels to split the release between?
                 n_phases_for_release = 1 + (phase == split_release_phase)
@@ -251,8 +252,9 @@ class ROEAbstract(object):
         referred_to_pixels = [0]
         for step in range(self.n_steps):
             for phase in range(self.n_phases):
-                for x in self.clock_sequence[step][phase]["capture_from_which_pixel"]:
-                    referred_to_pixels.append(x)
+                referred_to_pixels.append( self.clock_sequence[step][phase]["capture_from_which_pixel"] )
+                #for x in self.clock_sequence[step][phase]["capture_from_which_pixel"]:
+                #    referred_to_pixels.append(x)
                 for x in self.clock_sequence[step][phase]["release_to_which_pixel"]:
                     referred_to_pixels.append(x)
         return sorted(set(referred_to_pixels))

--- a/arctic/roe.py
+++ b/arctic/roe.py
@@ -407,21 +407,21 @@ class ROE(ROEAbstract):
         window = range(pixels) if isinstance(pixels, int) else pixels
         n_pixels = max(window) + 1
         express = n_pixels if express == 0 else min((express, n_pixels + offset))
-        #if isinstance(pixels, int):
+        # if isinstance(pixels, int):
         #    n_pixels = pixels
         #    window = range(n_pixels)
-        #else:
+        # else:
         #    window = pixels
         #    n_pixels = max(window) + 1
-        #if express == 0:
+        # if express == 0:
         #    express = n_pixels # Can allow express > n_pixels
-        
+
         # Temporarily ignore the first pixel-to-pixel transfer, if it is to be handled differently than the rest
         if self.empty_traps_at_start and express < n_pixels:
             n_pixels -= 1
 
         # Compute the multiplier factors
-        max_multiplier = ( n_pixels + offset ) / express
+        max_multiplier = (n_pixels + offset) / express
         # if it's going to be an integer, ceil() rather than int() is required in case the number of pixels is not an integer multiple of express
         if dtype == int:
             max_multiplier = int(np.ceil(max_multiplier))
@@ -443,7 +443,7 @@ class ROE(ROEAbstract):
             express_matrix_small = express_matrix
             # Create a new matrix for the full number of transfers
             n_pixels += 1
-            express_matrix = np.flipud(np.identity(n_pixels + offset , dtype=dtype))
+            express_matrix = np.flipud(np.identity(n_pixels + offset, dtype=dtype))
             # Insert the original transfers into the new matrix at appropriate places
             n_nonzero = np.sum(express_matrix_small > 0, axis=1)
             express_matrix[n_nonzero, 1:] += express_matrix_small
@@ -646,7 +646,9 @@ class ROETrapPumping(ROEAbstract):
         """
         if not isinstance(value, list):
             value = [value]
-        self._dwell_times = value # This must go before the even check, because n_steps uses it.
+        self._dwell_times = (
+            value  # This must go before the even check, because n_steps uses it.
+        )
         if (self.n_steps % 2) == 1:
             raise Exception("n_steps must be even for a complete trap pumping sequence")
 

--- a/arctic/roe.py
+++ b/arctic/roe.py
@@ -206,10 +206,12 @@ class ROEAbstract(object):
             for phase in range(n_phases):
 
                 # Where to capture from?
-                #capture_from_which_pixel = np.array(
+                # capture_from_which_pixel = np.array(
                 #    [(step_prime - phase + ((n_phases - 1) // 2)) // n_phases]
-                #)
-                capture_from_which_pixel = (step_prime - phase + ((n_phases - 1) // 2)) // n_phases
+                # )
+                capture_from_which_pixel = (
+                    step_prime - phase + ((n_phases - 1) // 2)
+                ) // n_phases
 
                 # How many pixels to split the release between?
                 n_phases_for_release = 1 + (phase == split_release_phase)
@@ -252,8 +254,10 @@ class ROEAbstract(object):
         referred_to_pixels = [0]
         for step in range(self.n_steps):
             for phase in range(self.n_phases):
-                referred_to_pixels.append( self.clock_sequence[step][phase]["capture_from_which_pixel"] )
-                #for x in self.clock_sequence[step][phase]["capture_from_which_pixel"]:
+                referred_to_pixels.append(
+                    self.clock_sequence[step][phase]["capture_from_which_pixel"]
+                )
+                # for x in self.clock_sequence[step][phase]["capture_from_which_pixel"]:
                 #    referred_to_pixels.append(x)
                 for x in self.clock_sequence[step][phase]["release_to_which_pixel"]:
                     referred_to_pixels.append(x)

--- a/arctic/trap_managers.py
+++ b/arctic/trap_managers.py
@@ -196,9 +196,9 @@ class TrapManager(object):
             traps = [traps]
         self.traps = traps
         self._n_pixels = n_pixels
-        #print(ccd.fraction_of_traps)
+        
+        # Will not be necessary soon
         if ccd is None: ccd = CCD()
-        print(ccd.fraction_of_traps)
         self.ccd = ccd
         self.phase = phase
         
@@ -212,8 +212,7 @@ class TrapManager(object):
             ),
             dtype=float,  # first +1 is to ensure there is always at least one zero; second is for volume column
         )
-        # The value for a filled watermark level, here 1 as a fill fraction
-        self.filled_watermark_value = 1
+        #self.filled_watermark_value = 1
 
         # Trap rates
         self.capture_rates = np.array([trap.capture_rate for trap in traps])
@@ -222,6 +221,12 @@ class TrapManager(object):
 
         # Are they surface traps?
         self.surface = np.array([trap.surface for trap in traps], dtype=bool)
+
+
+    # The value for a filled watermark level, here 1 as a fill fraction
+    @property
+    def filled_watermark_value(self):
+        return 1
 
     # Total number of trap species within this trap manager
     @property
@@ -1207,13 +1212,18 @@ class TrapManagerTrackTime(TrapManagerInstantCapture):
              ...                        ]
     """
 
-    def __init__(self, traps, n_pixels, ccd=None, phase=0):
-        super(TrapManagerTrackTime, self).__init__(
-            traps=traps, n_pixels=n_pixels, ccd=ccd, phase=phase
-        )
-
-        # The value for a filled watermark level, here 0 as an elapsed time
-        self.filled_watermark_value = 0
+    #def __init__(self, traps, n_pixels, ccd=None, phase=0):
+    #    super(TrapManagerTrackTime, self).__init__(
+    #        traps=traps, n_pixels=n_pixels, ccd=ccd, phase=phase
+    #    )
+    #
+    #    # The value for a filled watermark level, here 0 as an elapsed time
+    #    self.filled_watermark_value = 0
+    
+    # The value for a filled watermark level, here 0 as an elapsed time
+    @property
+    def filled_watermark_value(self):
+        return 0
 
     def watermarks_converted_to_fill_fractions_from_elapsed_times(self, watermarks):
         """ Convert the watermark values to fill fractions.

--- a/arctic/traps.py
+++ b/arctic/traps.py
@@ -6,11 +6,7 @@ from arctic import util
 
 class Trap(object):
     def __init__(
-        self,
-        density=0.13,
-        release_timescale=0.25,
-        capture_timescale=0,
-        surface=False,
+        self, density=0.13, release_timescale=0.25, capture_timescale=0, surface=False,
     ):
         """The parameters for a single trap species.
 
@@ -34,15 +30,14 @@ class Trap(object):
         self.release_timescale = release_timescale
         self.capture_timescale = capture_timescale
         self.surface = surface
-        
+
         # Rates
         self.emission_rate = 1 / self.release_timescale
         if self.capture_timescale == 0:
             self.capture_rate = np.inf
         else:
             self.capture_rate = 1 / self.capture_timescale
-    
-    
+
     def distribution_within_pixel(self, fractional_volume=0):
         return None
 

--- a/arctic/traps.py
+++ b/arctic/traps.py
@@ -1,7 +1,6 @@
 import numpy as np
 from scipy import integrate, optimize
 from copy import deepcopy
-from arctic.ccd import CCD
 from arctic import util
 
 
@@ -11,9 +10,7 @@ class Trap(object):
         density=0.13,
         release_timescale=0.25,
         capture_timescale=0,
-        ccd=None,
         surface=False,
-        discrete=False,
     ):
         """The parameters for a single trap species.
 
@@ -33,22 +30,21 @@ class Trap(object):
             The capture and emission rates (Lindegren (1998) section 3.2).
         """
 
-        if ccd is None:
-            ccd = CCD()
-
         self.density = float(density)
         self.release_timescale = release_timescale
         self.capture_timescale = capture_timescale
-        self.ccd = ccd
         self.surface = surface
-        self.discrete = discrete
-
+        
         # Rates
         self.emission_rate = 1 / self.release_timescale
         if self.capture_timescale == 0:
             self.capture_rate = np.inf
         else:
             self.capture_rate = 1 / self.capture_timescale
+    
+    
+    def distribution_within_pixel(self, fractional_volume=0):
+        return None
 
     def fill_fraction_from_time_elapsed(self, time_elapsed):
         """ Calculate the fraction of filled traps after a certain time_elapsed.
@@ -189,7 +185,7 @@ class Trap(object):
 class TrapInstantCapture(Trap):
     """ For the old C++ style release-then-instant-capture algorithm. """
 
-    def __init__(self, density=0.13, release_timescale=0.25, ccd=None, surface=False):
+    def __init__(self, density=0.13, release_timescale=0.25, surface=False):
         """The parameters for a single trap species.
 
         Parameters
@@ -200,12 +196,11 @@ class TrapInstantCapture(Trap):
             The release timescale of the trap, in the same units as the time 
             spent in each pixel or phase (Clocker sequence).
         """
-        super(TrapInstantCapture, self).__init__(
+        super().__init__(
             density=density,
             release_timescale=release_timescale,
             capture_timescale=0,
-            ccd=None,
-            surface=False,
+            surface=surface,
         )
 
 

--- a/arctic/traps.py
+++ b/arctic/traps.py
@@ -41,41 +41,6 @@ class Trap(object):
     def distribution_within_pixel(self, fractional_volume=0):
         return None
 
-    def cumulative_n_traps_from_n_electrons(self, n_electrons):
-        #
-        # RJM: this is not currently used. But it could be....
-        #
-
-        well_depth = self.ccd.full_well_depth
-        if self.surface:
-            alpha = self.ccd.blooming_level
-            beta = 1
-            # Let surface traps soak up everything they can, as a cheap way of
-            # ensuring that (at least with instantaneous trapping), no pixel in
-            # an output image will ever contain more electrons than the full
-            # well depth.
-            extra_traps = min(n_electrons - well_depth, 0)
-        else:
-            alpha = self.ccd.well_notch_depth
-            beta = self.ccd.well_fill_power
-            extra_traps = 0
-
-        n_electrons_available = n_electrons - alpha
-        n_traps = (
-            self.density
-            * util.set_min_max((n_electrons_available) / (well_depth - alpha), 0, 1)
-            ** beta
-        )
-        n_traps += extra_traps
-
-        # Make sure that the effective number of traps available cannot exceed
-        # the number of electrons. Adjusting this here is algorithmically much
-        # easier than catching lots of excpetions when there are insufficient
-        # electrons to fill traps during the capture process.
-        n_traps = min(n_traps, n_electrons_available)
-
-        return n_traps
-
     def fill_fraction_from_time_elapsed(self, time_elapsed):
         """ Calculate the fraction of filled traps after a certain time_elapsed.
 
@@ -412,3 +377,86 @@ class TrapLogNormalLifetimeContinuum(TrapLifetimeContinuum):
             release_timescale_mu=release_timescale_mu,
             release_timescale_sigma=release_timescale_sigma,
         )
+
+
+#
+#
+# RANDOM STUFF FOR FUTURE ADOPTION
+#
+#
+
+
+class TrapNonUniformHeightDistribution(Trap):
+
+    # Modify the effective height for non-uniform trap distributions... inside electrons_captured_in_pixel
+    #
+    # RJM: this is the only thing different in this entire class! Can duplicate code be excised
+    #      by creating a method self.electron_fractional_height_from_electrons in Trap, which
+    #      just calls ccd_volume.electron_fractional_height_from_electrons, but modifying it here?
+    #
+    # electron_fractional_height = self.effective_non_uniform_electron_fractional_height(
+    #    electron_fractional_height
+    # )
+    """ For a non-uniform distribution of traps with height within the pixel.
+    """
+
+    def __init__(
+        self,
+        density,
+        lifetime,
+        electron_fractional_height_min,
+        electron_fractional_height_max,
+    ):
+        """The parameters for a single trap species. 
+        Parameters
+        ----------
+        density : float
+            The density of the trap species in a pixel.
+        lifetime : float
+            The release lifetime of the trap.
+        electron_fractional_height_min, electron_fractional_height_max : float
+            The minimum (maximum) fractional height of the electron cloud in 
+            the pixel below (above) which corresponds to an effective fractional 
+            height of 0 (1), with a linear relation in between.
+        """
+        super(TrapNonUniformHeightDistribution, self).__init__(
+            density=density, lifetime=lifetime
+        )
+
+        self.electron_fractional_height_min = electron_fractional_height_min
+        self.electron_fractional_height_max = electron_fractional_height_max
+
+    def cumulative_n_traps_from_n_electrons(self, n_electrons):
+        #
+        # RJM: this is not currently used. But it could be....
+        #
+
+        well_depth = self.ccd.full_well_depth
+        if self.surface:
+            alpha = self.ccd.blooming_level
+            beta = 1
+            # Let surface traps soak up everything they can, as a cheap way of
+            # ensuring that (at least with instantaneous trapping), no pixel in
+            # an output image will ever contain more electrons than the full
+            # well depth.
+            extra_traps = min(n_electrons - well_depth, 0)
+        else:
+            alpha = self.ccd.well_notch_depth
+            beta = self.ccd.well_fill_power
+            extra_traps = 0
+
+        n_electrons_available = n_electrons - alpha
+        n_traps = (
+            self.density
+            * util.set_min_max((n_electrons_available) / (well_depth - alpha), 0, 1)
+            ** beta
+        )
+        n_traps += extra_traps
+
+        # Make sure that the effective number of traps available cannot exceed
+        # the number of electrons. Adjusting this here is algorithmically much
+        # easier than catching lots of excpetions when there are insufficient
+        # electrons to fill traps during the capture process.
+        n_traps = min(n_traps, n_electrons_available)
+
+        return n_traps

--- a/arctic/traps.py
+++ b/arctic/traps.py
@@ -41,6 +41,41 @@ class Trap(object):
     def distribution_within_pixel(self, fractional_volume=0):
         return None
 
+    def cumulative_n_traps_from_n_electrons(self, n_electrons):
+        #
+        # RJM: this is not currently used. But it could be....
+        #
+
+        well_depth = self.ccd.full_well_depth
+        if self.surface:
+            alpha = self.ccd.blooming_level
+            beta = 1
+            # Let surface traps soak up everything they can, as a cheap way of
+            # ensuring that (at least with instantaneous trapping), no pixel in
+            # an output image will ever contain more electrons than the full
+            # well depth.
+            extra_traps = min(n_electrons - well_depth, 0)
+        else:
+            alpha = self.ccd.well_notch_depth
+            beta = self.ccd.well_fill_power
+            extra_traps = 0
+
+        n_electrons_available = n_electrons - alpha
+        n_traps = (
+            self.density
+            * util.set_min_max((n_electrons_available) / (well_depth - alpha), 0, 1)
+            ** beta
+        )
+        n_traps += extra_traps
+
+        # Make sure that the effective number of traps available cannot exceed
+        # the number of electrons. Adjusting this here is algorithmically much
+        # easier than catching lots of excpetions when there are insufficient
+        # electrons to fill traps during the capture process.
+        n_traps = min(n_traps, n_electrons_available)
+
+        return n_traps
+
     def fill_fraction_from_time_elapsed(self, time_elapsed):
         """ Calculate the fraction of filled traps after a certain time_elapsed.
 

--- a/test_arctic/unit/test_main.py
+++ b/test_arctic/unit/test_main.py
@@ -9,7 +9,8 @@ import arctic as ac
 #
 # Check trailing of trails
 # Multiphase vs single phase
-# Bookkeepng - conservation of initial n_electrons 
+# Bookkeepng - conservation of initial n_electrons
+
 
 class TestGeneral:
     def test__add_cti__parallel_only__single_pixel__compare_cplusplus_version(self,):

--- a/test_arctic/unit/test_main.py
+++ b/test_arctic/unit/test_main.py
@@ -4,6 +4,13 @@ import pytest
 import arctic as ac
 
 
+#
+# Unit tests still To Do:
+#
+# Check trailing of trails
+# Multiphase vs single phase
+# Bookkeepng - conservation of initial n_electrons 
+
 class TestGeneral:
     def test__add_cti__parallel_only__single_pixel__compare_cplusplus_version(self,):
         image = np.zeros((6, 2))

--- a/test_arctic/unit/test_roe.py
+++ b/test_arctic/unit/test_roe.py
@@ -9,17 +9,17 @@ class TestExpress:
     #    def test__trailing_of_trails(self):
     #        assert False, "TBD"
 
-    def test__express_matrix_from_rows(self):
+    def test__express_matrix_from_pixels(self):
 
         roe = ac.ROE(empty_traps_at_start=False)
         express_multiplier, _ = roe.express_matrix_from_pixels_and_express(
-            rows=12, express=1, dtype=int
+            pixels=12, express=1, dtype=int
         )
 
         assert express_multiplier == pytest.approx(np.array([np.arange(1, 13)]))
 
         express_multiplier, _ = roe.express_matrix_from_pixels_and_express(
-            rows=12, express=4, dtype=int
+            pixels=12, express=4, dtype=int
         )
 
         assert express_multiplier == pytest.approx(
@@ -34,18 +34,18 @@ class TestExpress:
         )
 
         express_multiplier, _ = roe.express_matrix_from_pixels_and_express(
-            rows=12, express=12
+            pixels=12, express=12
         )
 
         assert express_multiplier == pytest.approx(np.triu(np.ones((12, 12))))
 
         roe = ac.ROE(empty_traps_at_start=True)
         express_multiplier, _ = roe.express_matrix_from_pixels_and_express(
-            rows=12, express=12
+            pixels=12, express=12
         )
 
     def test__express_matrix_always_sums_to_n_transfers(self):
-        for rows in [5, 7, 17]:
+        for pixels in [5, 7, 17]:
             for express in [0, 1, 2, 7]:
                 for offset in [0, 1, 13]:
                     for dtype in [int, float]:
@@ -55,10 +55,10 @@ class TestExpress:
                                 express_multiplier,
                                 _,
                             ) = roe.express_matrix_from_pixels_and_express(
-                                rows=rows, express=express, offset=offset, dtype=dtype
+                                pixels=pixels, express=express, offset=offset, dtype=dtype
                             )
                             assert np.sum(express_multiplier, axis=0) == pytest.approx(
-                                np.arange(1, rows + 1) + offset
+                                np.arange(1, pixels + 1) + offset
                             )
 
 

--- a/test_arctic/unit/test_roe.py
+++ b/test_arctic/unit/test_roe.py
@@ -55,7 +55,10 @@ class TestExpress:
                                 express_multiplier,
                                 _,
                             ) = roe.express_matrix_from_pixels_and_express(
-                                pixels=pixels, express=express, offset=offset, dtype=dtype
+                                pixels=pixels,
+                                express=express,
+                                offset=offset,
+                                dtype=dtype,
                             )
                             assert np.sum(express_multiplier, axis=0) == pytest.approx(
                                 np.arange(1, pixels + 1) + offset

--- a/test_arctic/unit/test_traps.py
+++ b/test_arctic/unit/test_traps.py
@@ -1805,3 +1805,86 @@ class TestElectronsReleasedAndCapturedIncludingSlowTraps:
 
         # Only capture the available electrons
         assert trapped_electrons_final == pytest.approx(n_free_electrons)
+
+
+
+
+#class TestTrapManagerNonUniformHeightDistribution:
+#    def test__effective_non_uniform_electron_fractional_height(self):
+#
+#        traps = [
+#            ac.TrapNonUniformHeightDistribution(
+#                density=10,
+#                lifetime=-1 / np.log(0.5),
+#                electron_fractional_height_min=0.95,
+#                electron_fractional_height_max=1,
+#            )
+#        ]
+#        trap_manager = ac.TrapManagerNonUniformHeightDistribution(traps=traps, rows=6,)
+#
+#        assert trap_manager.effective_non_uniform_electron_fractional_height(0.9) == 0
+#        assert trap_manager.effective_non_uniform_electron_fractional_height(1) == 1
+#        assert (
+#            trap_manager.effective_non_uniform_electron_fractional_height(0.975) == 0.5
+#        )
+#
+#    def test__first_capture(self):
+#
+#        traps = [
+#            ac.TrapNonUniformHeightDistribution(
+#                density=10,
+#                lifetime=-1 / np.log(0.5),
+#                electron_fractional_height_min=0.95,
+#                electron_fractional_height_max=1,
+#            )
+#        ]
+#        trap_manager = ac.TrapManagerNonUniformHeightDistribution(traps=traps, rows=6,)
+#
+#        electron_fractional_height = 0.5
+#
+#        electrons_captured = trap_manager.electrons_captured_by_traps(
+#            electron_fractional_height=electron_fractional_height,
+#            watermarks=trap_manager.watermarks,
+#            traps=trap_manager.traps,
+#        )
+#
+#        assert electrons_captured == pytest.approx(0.5 * 10)
+#
+#        trap_manager = ac.TrapManagerNonUniformHeightDistribution(traps=traps, rows=6,)
+#
+#        electron_fractional_height = 0.99
+#
+#        electrons_captured = trap_manager.electrons_captured_by_traps(
+#            electron_fractional_height=electron_fractional_height,
+#            watermarks=trap_manager.watermarks,
+#            traps=trap_manager.traps,
+#        )
+#
+#        assert electrons_captured == pytest.approx(0.99 * 10)
+#
+#    def test__middle_new_watermarks(self):
+#
+#        traps = [
+#            ac.TrapNonUniformHeightDistribution(
+#                density=10,
+#                lifetime=-1 / np.log(0.5),
+#                electron_fractional_height_min=0.95,
+#                electron_fractional_height_max=1,
+#            )
+#        ]
+#        trap_manager = ac.TrapManagerNonUniformHeightDistribution(traps=traps, rows=6,)
+#
+#        trap_manager.watermarks = np.array(
+#            [[0.96, 0.8], [0.98, 0.4], [0.99, 0.3], [0, 0], [0, 0], [0, 0]]
+#        )
+#        electron_fractional_height = 0.97
+#
+#        electrons_captured = trap_manager.electrons_captured_by_traps(
+#            electron_fractional_height=electron_fractional_height,
+#            watermarks=trap_manager.watermarks,
+#            traps=trap_manager.traps,
+#        )
+#
+#        assert electrons_captured == pytest.approx((0.96 * 0.2 + 0.01 * 0.6) * 10)
+#
+

--- a/test_arctic/unit/test_traps.py
+++ b/test_arctic/unit/test_traps.py
@@ -400,17 +400,15 @@ class TestElectronsReleasedAndCapturedInstantCapture:
     def test__first_capture(self):
 
         n_free_electrons = 2500  # --> cloud_fractional_volume = 0.5
-
+        
+        ccd = ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7)
         traps = [ac.TrapInstantCapture(density=10, release_timescale=-1 / np.log(0.5))]
+
         trap_manager = ac.TrapManagerInstantCapture(traps=traps, n_pixels=6)
 
-        ccd = ac.CCDPhase(
-            ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7),
-            phase=0,
-        )
-
         n_electrons_captured = trap_manager.n_electrons_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         assert n_electrons_captured == pytest.approx(5)
@@ -422,6 +420,7 @@ class TestElectronsReleasedAndCapturedInstantCapture:
 
         n_free_electrons = 3600  # --> cloud_fractional_volume = 0.6
 
+        ccd = ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7)
         traps = [
             ac.TrapInstantCapture(density=10, release_timescale=-1 / np.log(0.5)),
             ac.TrapInstantCapture(density=8, release_timescale=-1 / np.log(0.2)),
@@ -439,13 +438,9 @@ class TestElectronsReleasedAndCapturedInstantCapture:
             ]
         )
 
-        ccd = ac.CCDPhase(
-            ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7),
-            phase=0,
-        )
-
         n_electrons_captured = trap_manager.n_electrons_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         assert n_electrons_captured == pytest.approx(
@@ -470,16 +465,14 @@ class TestElectronsReleasedAndCapturedInstantCapture:
             2.5e-3  # --> cloud_fractional_volume = 4.9999e-4, enough=enough = 0.50001
         )
 
+        ccd = ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7)
+        
         traps = [ac.TrapInstantCapture(density=10, release_timescale=-1 / np.log(0.5))]
         trap_manager = ac.TrapManagerInstantCapture(traps=traps, n_pixels=6)
 
-        ccd = ac.CCDPhase(
-            ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7),
-            phase=0,
-        )
-
         n_electrons_captured = trap_manager.n_electrons_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         assert n_electrons_captured == pytest.approx(0.0025)
@@ -495,6 +488,8 @@ class TestElectronsReleasedAndCapturedInstantCapture:
             4.839e-4  # --> cloud_fractional_volume = 2.199545e-4, enough=enough = 0.5
         )
 
+        ccd = ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7)
+        
         traps = [
             ac.TrapInstantCapture(density=10, release_timescale=-1 / np.log(0.5)),
             ac.TrapInstantCapture(density=8, release_timescale=-1 / np.log(0.2)),
@@ -512,13 +507,9 @@ class TestElectronsReleasedAndCapturedInstantCapture:
             ]
         )
 
-        ccd = ac.CCDPhase(
-            ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7),
-            phase=0,
-        )
-
         n_electrons_captured = trap_manager.n_electrons_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function = ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         assert n_electrons_captured == pytest.approx(
@@ -544,10 +535,7 @@ class TestElectronsReleasedAndCapturedInstantCapture:
             ac.TrapInstantCapture(density=8, release_timescale=-1 / np.log(0.2)),
         ]
         trap_manager_1 = ac.TrapManagerInstantCapture(traps=traps, n_pixels=6)
-        ccd = ac.CCDPhase(
-            ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7),
-            phase=0,
-        )
+        ccd = ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7)
 
         n_free_electrons = 3600  # --> cloud_fractional_volume = 0.6
 
@@ -566,12 +554,14 @@ class TestElectronsReleasedAndCapturedInstantCapture:
         # Deprecated separate functions
         n_electrons_released = trap_manager_1.n_electrons_released()
         n_electrons_captured = trap_manager_1.n_electrons_captured(
-            n_free_electrons=n_free_electrons + n_electrons_released, ccd=ccd
+            n_free_electrons=n_free_electrons + n_electrons_released, 
+            ccd_filling_function = ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         # Combined function
         n_electrons_released_and_captured = trap_manager_2.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function = ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         # Same net electrons and updated watermarks
@@ -668,7 +658,7 @@ class TestTrapManagerTrackTime:
 
         n_free_electrons = 5e4  # cloud_fractional_volume ~= 0.656
         ccd = ac.CCD(well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=1e-7)
-        ccd = ac.CCDPhase(ccd)
+        #ccd = ac.CCDPhase(ccd)
 
         trap = ac.TrapInstantCapture(density=10, release_timescale=-1 / np.log(0.5))
         trap_manager_fill = ac.TrapManagerInstantCapture(traps=[trap], n_pixels=6)
@@ -689,10 +679,10 @@ class TestTrapManagerTrackTime:
         )
 
         net_electrons_fill = trap_manager_fill.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd,
+            n_free_electrons=n_free_electrons, ccd_filling_function = ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
         net_electrons_time = trap_manager_time.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd,
+            n_free_electrons=n_free_electrons, ccd_filling_function = ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         assert net_electrons_fill == net_electrons_time
@@ -705,7 +695,7 @@ class TestTrapManagerTrackTime:
     def test__electrons_released_and_captured_using_time_multiple_traps(self):
         n_free_electrons = 1e3
         ccd = ac.CCD(well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=1e-7)
-        ccd = ac.CCDPhase(ccd)
+        #ccd = ac.CCDPhase(ccd)
 
         trap_1 = ac.TrapInstantCapture(density=10, release_timescale=-1 / np.log(0.5))
         trap_2 = ac.TrapInstantCapture(density=10, release_timescale=-2 / np.log(0.5))
@@ -748,10 +738,12 @@ class TestTrapManagerTrackTime:
         )
 
         net_electrons_fill = trap_manager_fill.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
         net_electrons_time = trap_manager_time.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         assert net_electrons_fill == pytest.approx(net_electrons_time)
@@ -928,7 +920,7 @@ class TestTrapLifetimeContinuum:
 
         n_free_electrons = 5e4  # cloud_fractional_volume ~= 0.656
         ccd = ac.CCD(well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=1e-7)
-        ccd = ac.CCDPhase(ccd)
+        #ccd = ac.CCDPhase(ccd)
 
         # Single trap
         trap = ac.TrapInstantCapture(density=10, release_timescale=1)
@@ -944,7 +936,8 @@ class TestTrapLifetimeContinuum:
             ]
         )
         net_electrons_single = trap_manager_single.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd,
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         # Narrow continuum
@@ -973,7 +966,8 @@ class TestTrapLifetimeContinuum:
             ]
         )
         net_electrons_narrow = trap_manager_narrow.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd,
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         # Continuum
@@ -997,7 +991,8 @@ class TestTrapLifetimeContinuum:
             ]
         )
         net_electrons_continuum = trap_manager_continuum.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd,
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         assert net_electrons_narrow == pytest.approx(net_electrons_single, rel=1e-4)
@@ -1044,7 +1039,6 @@ class TestTrapLifetimeContinuum:
     ):
 
         ccd = ac.CCD(well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=1e-7)
-        ccd = ac.CCDPhase(ccd)
 
         density = 10
         release_timescale = 5
@@ -1094,7 +1088,8 @@ class TestTrapLifetimeContinuum:
             [[0.5, t_elapsed], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0],]
         )
         net_electrons_continuum = trap_manager_continuum.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         # Separated continuum traps
@@ -1117,7 +1112,8 @@ class TestTrapLifetimeContinuum:
             [[0.5, t_elapsed, t_elapsed], [0] * 3, [0] * 3, [0] * 3, [0] * 3, [0] * 3,]
         )
         net_electrons_continuum_split = trap_manager_continuum_split.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         # Equivalent distributions of single traps, linearly spaced
@@ -1142,7 +1138,8 @@ class TestTrapLifetimeContinuum:
             ]
         )
         net_electrons_linear = trap_manager_linear.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
         )
 
         # Equivalent distributions of single traps, logarithmically spaced
@@ -1173,10 +1170,12 @@ class TestTrapLifetimeContinuum:
             ]
         )
         net_electrons_log = trap_manager_log.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase()
         )
         net_electrons_log_2 = trap_manager_log.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=ccd
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase()
         )
 
         assert net_electrons_continuum == pytest.approx(net_electrons_continuum_split)
@@ -1186,7 +1185,9 @@ class TestTrapLifetimeContinuum:
     def test__trails_from_continuum_traps_compare_with_distributions_of_single_traps(
         self,
     ):
-
+        
+        # This test is VERY slow!
+        
         size = 10
         pixels = np.arange(size)
         image_orig = np.zeros((size, 1))
@@ -1246,23 +1247,23 @@ class TestTrapLifetimeContinuum:
         do_plot = False
         # do_plot = True
 
-        size = 20
-        pixels = np.arange(size)
-        image_orig = np.zeros((size, 1))
-        image_orig[1, 0] = 1e4
-
-        ccd = ac.CCD(well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=1e-7)
-
-        density = 1000
-        release_timescale = 3
-
-        # Log-normal distribution
-        def trap_distribution(release_timescale, median, sigma):
-            return np.exp(
-                -((np.log(release_timescale) - np.log(median)) ** 2) / (2 * sigma ** 2)
-            ) / (release_timescale * sigma * np.sqrt(2 * np.pi))
-
         if do_plot:
+            size = 20
+            pixels = np.arange(size)
+            image_orig = np.zeros((size, 1))
+            image_orig[1, 0] = 1e4
+
+            ccd = ac.CCD(well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=1e-7)
+
+            density = 1000
+            release_timescale = 3
+
+            # Log-normal distribution
+            def trap_distribution(release_timescale, median, sigma):
+                return np.exp(
+                    -((np.log(release_timescale) - np.log(median)) ** 2) / (2 * sigma ** 2)
+                ) / (release_timescale * sigma * np.sqrt(2 * np.pi))
+
             plt.figure()
 
             # Single trap
@@ -1304,9 +1305,8 @@ class TestTrapLifetimeContinuum:
 
 class TestElectronsReleasedAndCapturedIncludingSlowTraps:
 
-    ccd = ac.CCD(well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=1e-7)
-    ccd = ac.CCDPhase(ccd)
-
+    ccd = ac.CCD(well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=0)
+    
     density = 10
     release_timescale = 1
 
@@ -1467,13 +1467,19 @@ class TestElectronsReleasedAndCapturedIncludingSlowTraps:
         n_free_electrons = 5e4  # cloud_fractional_volume ~= 0.656
 
         net_electrons_instant = self.trap_manager_instant.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            dwell_time=1,
         )
         net_electrons_fast = self.trap_manager_fast.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0),
+            dwell_time=1,
         )
         net_electrons_slow = self.trap_manager_slow.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0),
+            dwell_time=1,
         )
 
         # Fast traps reproduce old-style behaviour
@@ -1500,13 +1506,19 @@ class TestElectronsReleasedAndCapturedIncludingSlowTraps:
         self.trap_manager_slow.watermarks = deepcopy(watermarks)
 
         net_electrons_instant = self.trap_manager_instant.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            dwell_time=1,
         )
         net_electrons_fast = self.trap_manager_fast.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0),
+            dwell_time=1,
         )
         net_electrons_slow = self.trap_manager_slow.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            dwell_time=1,
         )
 
         # Fast traps reproduce old-style behaviour
@@ -1542,13 +1554,19 @@ class TestElectronsReleasedAndCapturedIncludingSlowTraps:
         self.trap_manager_slow.watermarks = deepcopy(watermarks)
 
         net_electrons_instant = self.trap_manager_instant.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            dwell_time=1,
         )
         net_electrons_fast = self.trap_manager_fast.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            dwell_time=1,
         )
         net_electrons_slow = self.trap_manager_slow.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            dwell_time=1,
         )
 
         assert self.trap_manager_fast.watermarks == pytest.approx(
@@ -1587,13 +1605,19 @@ class TestElectronsReleasedAndCapturedIncludingSlowTraps:
         self.trap_manager_slow.watermarks = deepcopy(watermarks)
 
         net_electrons_instant = self.trap_manager_instant.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            dwell_time=1,
         )
         net_electrons_fast = self.trap_manager_fast.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            dwell_time=1,
         )
         net_electrons_slow = self.trap_manager_slow.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            dwell_time=1,
         )
 
         # Fast traps reproduce old-style behaviour
@@ -1615,6 +1639,7 @@ class TestElectronsReleasedAndCapturedIncludingSlowTraps:
 
     def test__no_available_electrons_slow_capture(self):
 
+        ccd = ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7)
         n_free_electrons = 0
 
         watermarks = np.array(
@@ -1625,13 +1650,19 @@ class TestElectronsReleasedAndCapturedIncludingSlowTraps:
         self.trap_manager_slow.watermarks = deepcopy(watermarks)
 
         net_electrons_instant = self.trap_manager_instant.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            dwell_time=1,
         )
         net_electrons_fast = self.trap_manager_fast.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            dwell_time=1,
         )
         net_electrons_slow = self.trap_manager_slow.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd=self.ccd, dwell_time=1,
+            n_free_electrons=n_free_electrons, 
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0),
+            dwell_time=1,
         )
 
         # Fast traps reproduce old-style behaviour

--- a/test_arctic/unit/test_traps.py
+++ b/test_arctic/unit/test_traps.py
@@ -400,7 +400,7 @@ class TestElectronsReleasedAndCapturedInstantCapture:
     def test__first_capture(self):
 
         n_free_electrons = 2500  # --> cloud_fractional_volume = 0.5
-        
+
         ccd = ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7)
         traps = [ac.TrapInstantCapture(density=10, release_timescale=-1 / np.log(0.5))]
 
@@ -408,7 +408,9 @@ class TestElectronsReleasedAndCapturedInstantCapture:
 
         n_electrons_captured = trap_manager.n_electrons_captured(
             n_free_electrons=n_free_electrons,
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         assert n_electrons_captured == pytest.approx(5)
@@ -440,7 +442,9 @@ class TestElectronsReleasedAndCapturedInstantCapture:
 
         n_electrons_captured = trap_manager.n_electrons_captured(
             n_free_electrons=n_free_electrons,
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         assert n_electrons_captured == pytest.approx(
@@ -466,13 +470,15 @@ class TestElectronsReleasedAndCapturedInstantCapture:
         )
 
         ccd = ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7)
-        
+
         traps = [ac.TrapInstantCapture(density=10, release_timescale=-1 / np.log(0.5))]
         trap_manager = ac.TrapManagerInstantCapture(traps=traps, n_pixels=6)
 
         n_electrons_captured = trap_manager.n_electrons_captured(
             n_free_electrons=n_free_electrons,
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         assert n_electrons_captured == pytest.approx(0.0025)
@@ -489,7 +495,7 @@ class TestElectronsReleasedAndCapturedInstantCapture:
         )
 
         ccd = ac.CCD(well_fill_power=0.5, full_well_depth=10000, well_notch_depth=1e-7)
-        
+
         traps = [
             ac.TrapInstantCapture(density=10, release_timescale=-1 / np.log(0.5)),
             ac.TrapInstantCapture(density=8, release_timescale=-1 / np.log(0.2)),
@@ -509,7 +515,9 @@ class TestElectronsReleasedAndCapturedInstantCapture:
 
         n_electrons_captured = trap_manager.n_electrons_captured(
             n_free_electrons=n_free_electrons,
-            ccd_filling_function = ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         assert n_electrons_captured == pytest.approx(
@@ -554,14 +562,18 @@ class TestElectronsReleasedAndCapturedInstantCapture:
         # Deprecated separate functions
         n_electrons_released = trap_manager_1.n_electrons_released()
         n_electrons_captured = trap_manager_1.n_electrons_captured(
-            n_free_electrons=n_free_electrons + n_electrons_released, 
-            ccd_filling_function = ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            n_free_electrons=n_free_electrons + n_electrons_released,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         # Combined function
         n_electrons_released_and_captured = trap_manager_2.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function = ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         # Same net electrons and updated watermarks
@@ -658,7 +670,7 @@ class TestTrapManagerTrackTime:
 
         n_free_electrons = 5e4  # cloud_fractional_volume ~= 0.656
         ccd = ac.CCD(well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=1e-7)
-        #ccd = ac.CCDPhase(ccd)
+        # ccd = ac.CCDPhase(ccd)
 
         trap = ac.TrapInstantCapture(density=10, release_timescale=-1 / np.log(0.5))
         trap_manager_fill = ac.TrapManagerInstantCapture(traps=[trap], n_pixels=6)
@@ -679,10 +691,16 @@ class TestTrapManagerTrackTime:
         )
 
         net_electrons_fill = trap_manager_fill.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd_filling_function = ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
         net_electrons_time = trap_manager_time.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, ccd_filling_function = ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         assert net_electrons_fill == net_electrons_time
@@ -695,7 +713,7 @@ class TestTrapManagerTrackTime:
     def test__electrons_released_and_captured_using_time_multiple_traps(self):
         n_free_electrons = 1e3
         ccd = ac.CCD(well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=1e-7)
-        #ccd = ac.CCDPhase(ccd)
+        # ccd = ac.CCDPhase(ccd)
 
         trap_1 = ac.TrapInstantCapture(density=10, release_timescale=-1 / np.log(0.5))
         trap_2 = ac.TrapInstantCapture(density=10, release_timescale=-2 / np.log(0.5))
@@ -738,12 +756,16 @@ class TestTrapManagerTrackTime:
         )
 
         net_electrons_fill = trap_manager_fill.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
         net_electrons_time = trap_manager_time.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         assert net_electrons_fill == pytest.approx(net_electrons_time)
@@ -920,7 +942,7 @@ class TestTrapLifetimeContinuum:
 
         n_free_electrons = 5e4  # cloud_fractional_volume ~= 0.656
         ccd = ac.CCD(well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=1e-7)
-        #ccd = ac.CCDPhase(ccd)
+        # ccd = ac.CCDPhase(ccd)
 
         # Single trap
         trap = ac.TrapInstantCapture(density=10, release_timescale=1)
@@ -937,7 +959,9 @@ class TestTrapLifetimeContinuum:
         )
         net_electrons_single = trap_manager_single.n_electrons_released_and_captured(
             n_free_electrons=n_free_electrons,
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         # Narrow continuum
@@ -967,7 +991,9 @@ class TestTrapLifetimeContinuum:
         )
         net_electrons_narrow = trap_manager_narrow.n_electrons_released_and_captured(
             n_free_electrons=n_free_electrons,
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         # Continuum
@@ -992,7 +1018,9 @@ class TestTrapLifetimeContinuum:
         )
         net_electrons_continuum = trap_manager_continuum.n_electrons_released_and_captured(
             n_free_electrons=n_free_electrons,
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         assert net_electrons_narrow == pytest.approx(net_electrons_single, rel=1e-4)
@@ -1089,7 +1117,9 @@ class TestTrapLifetimeContinuum:
         )
         net_electrons_continuum = trap_manager_continuum.n_electrons_released_and_captured(
             n_free_electrons=n_free_electrons,
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         # Separated continuum traps
@@ -1113,7 +1143,9 @@ class TestTrapLifetimeContinuum:
         )
         net_electrons_continuum_split = trap_manager_continuum_split.n_electrons_released_and_captured(
             n_free_electrons=n_free_electrons,
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         # Equivalent distributions of single traps, linearly spaced
@@ -1139,7 +1171,9 @@ class TestTrapLifetimeContinuum:
         )
         net_electrons_linear = trap_manager_linear.n_electrons_released_and_captured(
             n_free_electrons=n_free_electrons,
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0)
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
         )
 
         # Equivalent distributions of single traps, logarithmically spaced
@@ -1171,11 +1205,11 @@ class TestTrapLifetimeContinuum:
         )
         net_electrons_log = trap_manager_log.n_electrons_released_and_captured(
             n_free_electrons=n_free_electrons,
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase()
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(),
         )
         net_electrons_log_2 = trap_manager_log.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase()
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(),
         )
 
         assert net_electrons_continuum == pytest.approx(net_electrons_continuum_split)
@@ -1185,9 +1219,9 @@ class TestTrapLifetimeContinuum:
     def test__trails_from_continuum_traps_compare_with_distributions_of_single_traps(
         self,
     ):
-        
+
         # This test is VERY slow!
-        
+
         size = 10
         pixels = np.arange(size)
         image_orig = np.zeros((size, 1))
@@ -1253,7 +1287,9 @@ class TestTrapLifetimeContinuum:
             image_orig = np.zeros((size, 1))
             image_orig[1, 0] = 1e4
 
-            ccd = ac.CCD(well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=1e-7)
+            ccd = ac.CCD(
+                well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=1e-7
+            )
 
             density = 1000
             release_timescale = 3
@@ -1261,7 +1297,8 @@ class TestTrapLifetimeContinuum:
             # Log-normal distribution
             def trap_distribution(release_timescale, median, sigma):
                 return np.exp(
-                    -((np.log(release_timescale) - np.log(median)) ** 2) / (2 * sigma ** 2)
+                    -((np.log(release_timescale) - np.log(median)) ** 2)
+                    / (2 * sigma ** 2)
                 ) / (release_timescale * sigma * np.sqrt(2 * np.pi))
 
             plt.figure()
@@ -1306,7 +1343,7 @@ class TestTrapLifetimeContinuum:
 class TestElectronsReleasedAndCapturedIncludingSlowTraps:
 
     ccd = ac.CCD(well_fill_power=0.8, full_well_depth=8.47e4, well_notch_depth=0)
-    
+
     density = 10
     release_timescale = 1
 
@@ -1467,18 +1504,24 @@ class TestElectronsReleasedAndCapturedIncludingSlowTraps:
         n_free_electrons = 5e4  # cloud_fractional_volume ~= 0.656
 
         net_electrons_instant = self.trap_manager_instant.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
         net_electrons_fast = self.trap_manager_fast.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0),
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
         net_electrons_slow = self.trap_manager_slow.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0),
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
 
@@ -1506,18 +1549,24 @@ class TestElectronsReleasedAndCapturedIncludingSlowTraps:
         self.trap_manager_slow.watermarks = deepcopy(watermarks)
 
         net_electrons_instant = self.trap_manager_instant.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
         net_electrons_fast = self.trap_manager_fast.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0),
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
         net_electrons_slow = self.trap_manager_slow.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
 
@@ -1554,18 +1603,24 @@ class TestElectronsReleasedAndCapturedIncludingSlowTraps:
         self.trap_manager_slow.watermarks = deepcopy(watermarks)
 
         net_electrons_instant = self.trap_manager_instant.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
         net_electrons_fast = self.trap_manager_fast.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
         net_electrons_slow = self.trap_manager_slow.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
 
@@ -1605,18 +1660,24 @@ class TestElectronsReleasedAndCapturedIncludingSlowTraps:
         self.trap_manager_slow.watermarks = deepcopy(watermarks)
 
         net_electrons_instant = self.trap_manager_instant.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
         net_electrons_fast = self.trap_manager_fast.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
         net_electrons_slow = self.trap_manager_slow.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=self.ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
 
@@ -1650,18 +1711,24 @@ class TestElectronsReleasedAndCapturedIncludingSlowTraps:
         self.trap_manager_slow.watermarks = deepcopy(watermarks)
 
         net_electrons_instant = self.trap_manager_instant.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
         net_electrons_fast = self.trap_manager_fast.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0), 
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
         net_electrons_slow = self.trap_manager_slow.n_electrons_released_and_captured(
-            n_free_electrons=n_free_electrons, 
-            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(0),
+            n_free_electrons=n_free_electrons,
+            ccd_filling_function=ccd.cloud_fractional_volume_from_n_electrons_in_phase(
+                0
+            ),
             dwell_time=1,
         )
 


### PR DESCRIPTION
Minor restructuring of trap managers, so they contain a (wrapper) function for the CCD volume filling function. This adds flexibility. When n_electrons_released_and_captured() calls the well filling function, it can be redirected to ccd.cloud_fractional_volume_from_n_electrons() as before. But - in future edits still TBD - it can also be swapped out for a different n_trap(n_electron) curve for surface traps, or reweighted for trap (group) species that are nonuniformly distributed within a pixel.

The call to cloud_fractional_volume_from_n_electrons() happens MANY times, in the very centre of the main nested loop. There is therefore a risk of a cost in runtime. To avoid this, the wrapper function is set up in advance, to avoid runtime "if"s. It still adds a layer to the call stack, but I hope this shouldn't expect it to add (much) overhead to total runtimes.


