### PR TITLE
cython modifications

### DIFF
--- a/arcticpy/main.py
+++ b/arcticpy/main.py
@@ -28,6 +28,7 @@ from arcticpy.ccd import CCD, CCDPhase
 from arcticpy.trap_managers import AllTrapManager
 from arcticpy.traps import TrapInstantCapture
 from arcticpy import util
+from arcticpy.main_utils import cy_clock_charge_in_one_direction
 
 
 def _clock_charge_in_one_direction(
@@ -418,43 +419,40 @@ def add_cti(
     # Parallel clocking
     if parallel_traps is not None:
 
-        # Transfer charge in parallel direction
-        image_add_cti = _clock_charge_in_one_direction(
-            image=image_add_cti,
-            ccd=parallel_ccd,
-            roe=parallel_roe,
-            traps=parallel_traps,
-            express=parallel_express,
-            offset=parallel_offset,
-            window_row_range=parallel_window_range,
-            window_column_range=serial_window_range,
-            time_window_range=time_window_range,
+        image_add_cti = cy_clock_charge_in_one_direction(
+            image_add_cti,
+            parallel_ccd,
+            parallel_roe,
+            parallel_traps,
+            parallel_express,
+            parallel_offset,
+            parallel_window_range,
+            serial_window_range,
+            time_window_range,
         )
 
     # Serial clocking
     if serial_traps is not None:
-
         # Switch axes, so clocking happens in other direction
         image_add_cti = image_add_cti.T.copy()
 
         # Transfer charge in serial direction
-        image_add_cti = _clock_charge_in_one_direction(
-            image=image_add_cti,
-            ccd=serial_ccd,
-            roe=serial_roe,
-            traps=serial_traps,
-            express=serial_express,
-            offset=serial_offset,
-            window_row_range=serial_window_range,
-            window_column_range=serial_window_column_range,
-            time_window_range=None,
+        image_add_cti = cy_clock_charge_in_one_direction(
+            image_add_cti,
+            serial_ccd,
+            serial_roe,
+            serial_traps,
+            serial_express,
+            serial_offset,
+            serial_window_range,
+            serial_window_column_range,
+            None,
         )
 
         # Switch axes back
         image_add_cti = image_add_cti.T
 
     # TODO : Implement as decorator
-
     if isinstance(image, frames.Frame):
 
         return image.__class__(

--- a/arcticpy/main_utils.pyx
+++ b/arcticpy/main_utils.pyx
@@ -1,0 +1,192 @@
+cimport numpy as np
+import numpy as np
+
+import cython
+cimport cython
+
+from arcticpy.roe import ROETrapPumping
+from arcticpy.trap_managers import AllTrapManager
+
+
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+@cython.wraparound(False)
+#@cython.profile(True)
+def cy_clock_charge_in_one_direction(
+    image_in,
+    ccd,
+    roe,
+    traps,
+    express,
+    offset,
+    window_row_range,
+    window_column_range,
+    time_window_range,
+):
+    """
+    Add CTI trails to an image by trapping, releasing, and moving electrons 
+    along their independent columns.
+
+    Returns
+    -------
+    image : [[float]]
+        The output array of pixel values.
+    """
+
+    # Generate the arrays over each step for: the number of of times that the
+    # effect of each pixel-to-pixel transfer can be multiplied for the express
+    # algorithm; and whether the traps must be monitored (usually whenever
+    # express matrix > 0, unless using a time window)
+    cdef np.float64_t[:, ::1] express_matrix
+    cdef np.uint8_t[:, ::1] monitor_traps_matrix
+    (
+        express_matrix,
+        monitor_traps_matrix,
+    ) = roe.express_matrix_and_monitor_traps_matrix_from_pixels_and_express(
+        pixels=window_row_range,
+        express=express,
+        offset=offset,
+        time_window_range=time_window_range,
+    )
+
+    # ; and whether the trap occupancy states must be saved for the next express
+    # pass rather than being reset (usually at the end of each express pass)
+    save_trap_states_matrix = roe.save_trap_states_matrix_from_express_matrix(
+        express_matrix=express_matrix
+    )
+
+    cdef np.int64_t n_express_pass, n_rows_to_process
+    n_express_pass = express_matrix.shape[0]
+    n_rows_to_process = express_matrix.shape[1]
+
+    # Decide in advance which steps need to be evaluated and which can be skipped
+    cdef np.int64_t[:] phases_with_traps = np.array([
+        i for i, frac in enumerate(ccd.fraction_of_traps_per_phase) if frac > 0
+    ], dtype=np.int64)
+    cdef np.int64_t[:] steps_with_nonzero_dwell_time = np.array([
+        i for i, time in enumerate(roe.dwell_times) if time > 0
+    ], dtype=np.int64)
+
+    # Set up the set of trap managers to monitor the occupancy of all trap species
+    if isinstance(roe, ROETrapPumping):
+        # For trap pumping there is only one pixel and row to process but
+        # multiple transfers back and forth without clearing the watermarks
+        # Note, this allows for many more watermarks than are actually needed
+        # in standard trap-pumping clock sequences
+        max_n_transfers = n_express_pass * steps_with_nonzero_dwell_time.shape[0]
+    else:
+        max_n_transfers = n_rows_to_process * steps_with_nonzero_dwell_time.shape[0]
+
+    trap_managers = AllTrapManager(
+        traps=traps, max_n_transfers=max_n_transfers, ccd=ccd
+    )
+
+    # Temporarily expand image, if charge released from traps ever migrates to
+    # a different charge packet, at any time during the clocking sequence
+    n_rows_zero_padding = max(roe.pixels_accessed_during_clocking) - min(
+        roe.pixels_accessed_during_clocking
+    )
+    zero_padding = np.zeros((n_rows_zero_padding, image_in.shape[1]), dtype=np.float64)
+
+    cdef np.float64_t[:, :] image = np.concatenate((image_in, zero_padding), axis=0)
+
+    # Read out one column of pixels through the (column of) traps
+    cdef np.float64_t[:] n_free_electrons
+    cdef np.int64_t column_index, express_index, row_index, i
+    cdef np.int64_t[:] row_index_read, row_index_write
+    cdef np.float64_t n_electrons_released_and_captured, is_high, express_mulitplier
+    for column_index in window_column_range:
+        # Monitor the traps in every pixel, or just one (express=1) or a few
+        # (express=a few) then replicate their effect
+        for express_index in range(0, n_express_pass, 1):
+            # Restore the trap occupancy levels (to empty, or to a saved state
+            # from a previous express pass)
+            trap_managers.restore()
+
+            # Each pixel
+            for row_index in range(0, len(window_row_range), 1):
+                express_multiplier = express_matrix[express_index, row_index]
+                # Skip this step if not needed to be evaluated (may need to
+                # monitor the traps and update their occupancies even if
+                # express_mulitplier is 0, e.g. for a time window)
+                if monitor_traps_matrix[express_index, row_index] == 0:
+                    continue
+
+                for iclocking_step in range(steps_with_nonzero_dwell_time.shape[0]):
+                    clocking_step = steps_with_nonzero_dwell_time[iclocking_step]
+
+                    for iphase in range(phases_with_traps.shape[0]):
+                        phase = phases_with_traps[iphase]
+
+                        # Information about the potentials in this phase
+                        roe_phase = roe.clock_sequence[clocking_step][phase]
+
+                        # Select the relevant pixel (and phase) for the initial charge
+                        row_index_read = (
+                            window_row_range[row_index]
+                            + roe_phase.capture_from_which_pixels
+                        )
+
+                        # Initial charge (0 if this phase's potential is not high)
+                        n_free_electrons = np.zeros(row_index_read.shape[0])
+                        is_high = roe_phase.is_high
+                        for i in range(row_index_read.shape[0]):
+                            n_free_electrons[i] = (
+                                image[row_index_read[i], column_index] * is_high
+                            )
+
+                        # Allow electrons to be released from and captured by traps
+                        n_electrons_released_and_captured = 0
+                        for trap_manager in trap_managers[phase]:
+                            n_electrons_released_and_captured += trap_manager.n_electrons_released_and_captured(
+                                n_free_electrons=np.asarray(n_free_electrons),
+                                dwell_time=roe.dwell_times[clocking_step],
+                                ccd_filling_function=ccd.well_filling_function(
+                                    phase=phase
+                                ),
+                                express_multiplier=express_multiplier,
+                            )
+
+                        # Skip updating the image if only monitoring the traps
+                        if express_multiplier == 0:
+                            continue
+
+                        # Select the relevant pixel (and phase(s)) for the returned charge
+                        row_index_write = (
+                            window_row_range[row_index]
+                            + roe_phase.release_to_which_pixels
+                        )
+
+                        # Return the electrons back to the relevant charge
+                        # cloud, or a fraction if they are being returned to
+                        # multiple phases
+                        for i in range(row_index_write.shape[0]):
+                            image[row_index_write[i], column_index] += (
+                                n_electrons_released_and_captured
+                                * roe_phase.release_fraction_to_pixel[i]
+                                * express_multiplier
+                            )
+
+                        # Make sure image counts don't go negative, as could
+                        # otherwise happen with a too-large express_multiplier
+                        for i in range(0, row_index_write.shape[0], 1):
+                            if image[row_index_write[i], column_index] < 0:
+                                image[row_index_write[i], column_index] = 0
+
+                # Save the trap occupancy states for the next express pass
+                if save_trap_states_matrix[express_index, row_index]:
+                    trap_managers.save()
+
+        # Reset the watermarks for the next column, effectively setting the trap
+        # occupancies to zero
+        if roe.empty_traps_between_columns:
+            trap_managers.empty_all_traps()
+        trap_managers.save()
+
+    # Unexpand the image to its original dimensions
+    image_out = np.asarray(image)
+    if n_rows_zero_padding > 0:
+        image_out = image_out[0:-n_rows_zero_padding, :]
+
+    return image_out
+

--- a/arcticpy/main_utils.pyx
+++ b/arcticpy/main_utils.pyx
@@ -60,10 +60,10 @@ def cy_clock_charge_in_one_direction(
     n_rows_to_process = express_matrix.shape[1]
 
     # Decide in advance which steps need to be evaluated and which can be skipped
-    cdef np.int64_t[:] phases_with_traps = np.array([
+    cdef np.int64_t[::1] phases_with_traps = np.array([
         i for i, frac in enumerate(ccd.fraction_of_traps_per_phase) if frac > 0
     ], dtype=np.int64)
-    cdef np.int64_t[:] steps_with_nonzero_dwell_time = np.array([
+    cdef np.int64_t[::1] steps_with_nonzero_dwell_time = np.array([
         i for i, time in enumerate(roe.dwell_times) if time > 0
     ], dtype=np.int64)
 
@@ -91,9 +91,9 @@ def cy_clock_charge_in_one_direction(
     cdef np.float64_t[:, :] image = np.concatenate((image_in, zero_padding), axis=0)
 
     # Read out one column of pixels through the (column of) traps
-    cdef np.float64_t[:] n_free_electrons
+    cdef np.float64_t[::1] n_free_electrons
     cdef np.int64_t column_index, express_index, row_index, i
-    cdef np.int64_t[:] row_index_read, row_index_write
+    cdef np.int64_t[::1] row_index_read, row_index_write
     cdef np.float64_t n_electrons_released_and_captured, is_high, express_mulitplier
     for column_index in window_column_range:
         # Monitor the traps in every pixel, or just one (express=1) or a few

--- a/arcticpy/roe.py
+++ b/arcticpy/roe.py
@@ -530,7 +530,7 @@ class ROE(ROEAbstract):
         # Initialise an array with enough pixels to contain the supposed image,
         # including offset
         express_matrix = np.ndarray(
-            (express, n_pixels + offset), dtype=self.express_matrix_dtype
+            (express, n_pixels + offset), dtype=self.express_matrix_dtype,
         )
 
         # Compute the multiplier factors
@@ -579,7 +579,7 @@ class ROE(ROEAbstract):
         # Keep only the spatial region of interest
         express_matrix = express_matrix[:, window_range]
 
-        return express_matrix, monitor_traps_matrix
+        return np.ascontiguousarray(express_matrix), np.ascontiguousarray(monitor_traps_matrix)
 
     def save_trap_states_matrix_from_express_matrix(self, express_matrix):
         """

--- a/arcticpy/trap_managers.py
+++ b/arcticpy/trap_managers.py
@@ -11,6 +11,11 @@ from arcticpy.traps import (
 )
 from arcticpy.ccd import CCD, CCDPhase
 
+from arcticpy.trap_managers_utils import (
+    cy_n_trapped_electrons_from_watermarks,
+    cy_update_watermark_volumes_for_cloud_below_highest
+)
+
 
 class AllTrapManager(UserList):
     def __init__(self, traps, max_n_transfers, ccd):
@@ -350,8 +355,8 @@ class TrapManager(object):
             The watermarks. See 
             initial_watermarks_from_n_pixels_and_total_traps().
         """
-        return np.sum(
-            (watermarks[:, 0] * watermarks[:, 1:].T).T * self.n_traps_per_pixel
+        return cy_n_trapped_electrons_from_watermarks(
+            watermarks, np.array(self.n_traps_per_pixel, dtype=np.int64)
         )
 
     def empty_all_traps(self):

--- a/arcticpy/trap_managers.py
+++ b/arcticpy/trap_managers.py
@@ -417,33 +417,36 @@ class TrapManager(object):
             The updated watermarks. See 
             initial_watermarks_from_n_pixels_and_total_traps().
         """
+        cy_update_watermark_volumes_for_cloud_below_highest(
+            watermarks, cloud_fractional_volume, watermark_index_above_cloud)
+        return watermarks
         # The volume and cumulative volume of the watermark around the cloud volume
-        watermark_fractional_volume = watermarks[watermark_index_above_cloud, 0]
-        cumulative_watermark_fractional_volume = np.sum(
-            watermarks[: watermark_index_above_cloud + 1, 0]
-        )
+#        watermark_fractional_volume = watermarks[watermark_index_above_cloud, 0]
+#        cumulative_watermark_fractional_volume = np.sum(
+#            watermarks[: watermark_index_above_cloud + 1, 0]
+#        )
 
         # Move one new empty watermark to the start of the list
-        watermarks = np.roll(watermarks, 1, axis=0)
+#        watermarks = np.roll(watermarks, 1, axis=0)
 
         # Re-set the relevant watermarks near the start of the list
-        if watermark_index_above_cloud == 0:
-            watermarks[0] = watermarks[1]
-        else:
-            watermarks[: watermark_index_above_cloud + 1] = watermarks[
-                1 : watermark_index_above_cloud + 2
-            ]
+#        if watermark_index_above_cloud == 0:
+#            watermarks[0] = watermarks[1]
+#        else:
+#            watermarks[: watermark_index_above_cloud + 1] = watermarks[
+#                1 : watermark_index_above_cloud + 2
+#            ]
 
         # Update the new split watermarks' volumes
-        old_fractional_volume = watermark_fractional_volume
-        watermarks[watermark_index_above_cloud, 0] = cloud_fractional_volume - (
-            cumulative_watermark_fractional_volume - watermark_fractional_volume
-        )
-        watermarks[watermark_index_above_cloud + 1, 0] = (
-            old_fractional_volume - watermarks[watermark_index_above_cloud, 0]
-        )
-
-        return watermarks
+#        old_fractional_volume = watermark_fractional_volume
+#        watermarks[watermark_index_above_cloud, 0] = cloud_fractional_volume - (
+#            cumulative_watermark_fractional_volume - watermark_fractional_volume
+#        )
+#        watermarks[watermark_index_above_cloud + 1, 0] = (
+#            old_fractional_volume - watermarks[watermark_index_above_cloud, 0]
+#        )
+#
+#        return watermarks
 
     def updated_watermarks_from_capture_not_enough(
         self, watermarks, watermarks_initial, enough

--- a/arcticpy/trap_managers_utils.pyx
+++ b/arcticpy/trap_managers_utils.pyx
@@ -1,0 +1,94 @@
+import cython
+cimport cython
+
+import numpy as np
+cimport numpy as np
+
+from libc.stdlib cimport malloc, free
+
+
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+@cython.wraparound(False)
+cdef void roll_2d_vertical(np.float64_t[:, :] arr) nogil:
+    # Unfortunately we cannot use np.zeros without the gil, so good old fashioned
+    # C is used instead
+    cdef np.float64_t * arr_lr = <np.float64_t *> malloc(sizeof(np.float64_t) * arr.shape[1])
+    cdef np.int64_t i, j
+
+    # Copy the last row
+    for j in range(0, arr.shape[1], 1):
+        arr_lr[j] = arr[arr.shape[0]-1, j]
+
+    # Move all the rows up an index
+    for i in range(1, arr.shape[0], 1):
+        for j in range(0, arr.shape[1], 1):
+            arr[i, j] = arr[i-1, j]
+
+    # Put the copied last row into the 0 index
+    for j in range(0, arr.shape[1], 1):
+        arr[0, j] = arr_lr[j]
+
+    free(arr_lr)
+
+
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+@cython.wraparound(False)
+def cy_n_trapped_electrons_from_watermarks(np.float64_t[:, :] watermarks, np.int64_t[:] n_traps_per_pixel):
+    """ Sum the total number of electrons currently held in traps.
+    Parameters
+    ----------
+        watermarks : np.ndarray The watermarks.
+
+    See initial_watermarks_from_n_pixels_and_total_traps().
+    """
+    cdef np.float64_t total = 0.0
+    cdef np.int64_t i, j
+    with nogil:
+        for i in range(0, watermarks.shape[0], 1):
+            for j in range(1, watermarks.shape[1], 1):
+                total += watermarks[i, 0] * watermarks[i, j] * n_traps_per_pixel[j - 1]
+
+    return total
+
+
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+@cython.wraparound(False)
+def cy_update_watermark_volumes_for_cloud_below_highest(
+        np.float64_t[:, :] watermarks,
+        np.float64_t cloud_fractional_volume,
+        np.int64_t watermark_index_above_cloud):
+
+    # The volume and cumulative volume of the watermark around the cloud volume
+    cdef np.float64_t watermark_fractional_volume = watermarks[watermark_index_above_cloud, 0]
+    cdef np.float64_t cumulative_watermark_fractional_volume = 0.0
+    cdef np.float64_t old_fractional_volume = 0.0
+    cdef np.int64_t i, j
+
+    with nogil:
+        for i in range(0, watermark_index_above_cloud + 1, 1):
+            cumulative_watermark_fractional_volume +=  watermarks[i, 0]
+
+        # Move one new empty watermark to the start of the list
+        #watermarks = np.roll(watermarks, 1, axis=0)
+        roll_2d_vertical(watermarks)
+
+        # Re-set the relevant watermarks near the start of the list
+        if watermark_index_above_cloud == 0:
+            for j in range(0, watermarks.shape[1], 1):
+                watermarks[0, j] = watermarks[1, j]
+        else:
+            for i in range(0, watermark_index_above_cloud + 1, 1):
+                for j in range(0, watermarks.shape[1], 1):
+                    watermarks[i, j] = watermarks[i + 1, j]
+
+        # Update the new split watermarks' volumes
+        old_fractional_volume = watermark_fractional_volume
+        watermarks[watermark_index_above_cloud, 0] = cloud_fractional_volume - (
+            cumulative_watermark_fractional_volume - watermark_fractional_volume
+        )
+        watermarks[watermark_index_above_cloud + 1, 0] = (
+            old_fractional_volume - watermarks[watermark_index_above_cloud, 0]
+        )

--- a/arcticpy/trap_managers_utils.pyx
+++ b/arcticpy/trap_managers_utils.pyx
@@ -35,7 +35,7 @@ cdef void roll_2d_vertical(np.float64_t[:, :] arr) nogil:
 @cython.boundscheck(False)
 @cython.nonecheck(False)
 @cython.wraparound(False)
-def cy_n_trapped_electrons_from_watermarks(np.float64_t[:, :] watermarks, np.int64_t[:] n_traps_per_pixel):
+def cy_n_trapped_electrons_from_watermarks(np.float64_t[:, :] watermarks, np.float64_t[:] n_traps_per_pixel):
     """ Sum the total number of electrons currently held in traps.
     Parameters
     ----------
@@ -92,3 +92,25 @@ def cy_update_watermark_volumes_for_cloud_below_highest(
         watermarks[watermark_index_above_cloud + 1, 0] = (
             old_fractional_volume - watermarks[watermark_index_above_cloud, 0]
         )
+
+
+
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+@cython.wraparound(False)
+cpdef np.int64_t cy_watermark_index_above_cloud_from_cloud_fractional_volume(
+        np.float64_t cloud_fractional_volume, np.float64_t[:, :] watermarks, np.int64_t max_watermark_index
+):
+    cdef np.float64_t total = 0.0
+    cdef np.int64_t i
+    cdef np.int64_t index = watermarks.shape[0]
+    with nogil:
+        for i in range(watermarks.shape[0]):
+            total += watermarks[i, 0]
+            if cloud_fractional_volume <= total:
+                index = min(index, i)
+
+        if total < cloud_fractional_volume:
+            return max_watermark_index + 1
+        else:
+            return index

--- a/arcticpy/trap_managers_utils.pyx
+++ b/arcticpy/trap_managers_utils.pyx
@@ -5,6 +5,7 @@ import numpy as np
 cimport numpy as np
 
 from libc.stdlib cimport malloc, free
+from libc.math cimport exp
 
 
 @cython.boundscheck(False)
@@ -35,7 +36,7 @@ cdef void roll_2d_vertical(np.float64_t[:, :] arr) nogil:
 @cython.boundscheck(False)
 @cython.nonecheck(False)
 @cython.wraparound(False)
-def cy_n_trapped_electrons_from_watermarks(np.float64_t[:, :] watermarks, np.float64_t[:] n_traps_per_pixel):
+cpdef np.float64_t cy_n_trapped_electrons_from_watermarks(np.float64_t[:, :] watermarks, np.float64_t[:] n_traps_per_pixel):
     """ Sum the total number of electrons currently held in traps.
     Parameters
     ----------
@@ -56,7 +57,7 @@ def cy_n_trapped_electrons_from_watermarks(np.float64_t[:, :] watermarks, np.flo
 @cython.boundscheck(False)
 @cython.nonecheck(False)
 @cython.wraparound(False)
-def cy_update_watermark_volumes_for_cloud_below_highest(
+cpdef void cy_update_watermark_volumes_for_cloud_below_highest(
         np.float64_t[:, :] watermarks,
         np.float64_t cloud_fractional_volume,
         np.int64_t watermark_index_above_cloud):
@@ -94,7 +95,6 @@ def cy_update_watermark_volumes_for_cloud_below_highest(
         )
 
 
-
 @cython.boundscheck(False)
 @cython.nonecheck(False)
 @cython.wraparound(False)
@@ -114,3 +114,23 @@ cpdef np.int64_t cy_watermark_index_above_cloud_from_cloud_fractional_volume(
             return max_watermark_index + 1
         else:
             return index
+
+
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+@cython.wraparound(False)
+cpdef np.int64_t cy_value_in_cumsum(
+        np.float64_t value, np.float64_t[:] arr
+):
+    cdef np.float64_t total = arr[0]
+    cdef np.int64_t i
+    with nogil:
+        for i in range(1, arr.shape[0], 1):
+            if value == total:
+                return 1
+            total += arr[i]
+
+        if value == total:
+            return 1
+        else:
+            return 0

--- a/arcticpy/trap_managers_utils.pyx
+++ b/arcticpy/trap_managers_utils.pyx
@@ -23,7 +23,7 @@ cdef void roll_2d_vertical(np.float64_t[:, :] arr) nogil:
     # Move all the rows up an index
     for i in range(1, arr.shape[0], 1):
         for j in range(0, arr.shape[1], 1):
-            arr[i, j] = arr[i-1, j]
+            arr[arr.shape[0]-i, j] = arr[arr.shape[0]-i-1, j]
 
     # Put the copied last row into the 0 index
     for j in range(0, arr.shape[1], 1):
@@ -69,7 +69,7 @@ def cy_update_watermark_volumes_for_cloud_below_highest(
 
     with nogil:
         for i in range(0, watermark_index_above_cloud + 1, 1):
-            cumulative_watermark_fractional_volume +=  watermarks[i, 0]
+            cumulative_watermark_fractional_volume += watermarks[i, 0]
 
         # Move one new empty watermark to the start of the list
         #watermarks = np.roll(watermarks, 1, axis=0)

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,37 @@
 import setuptools
+from setuptools.extension import Extension
+import numpy as np
+
+from Cython.Build import cythonize
+from Cython.Compiler.Options import get_directive_defaults
+directive_defaults = get_directive_defaults()
+directive_defaults['linetrace'] = True
+directive_defaults['binding'] = True
+
 
 with open("README.md", "r") as f:
     long_description = f.read()
 
 with open("requirements.txt", "r") as f:
     requirements = f.read().split("\n")
+
+link_args = ["-std=c99"]
+ext_modules = [
+    Extension("arcticpy.trap_managers_utils", ["arcticpy/trap_managers_utils.pyx"],
+            extra_compile_args=link_args,
+            extra_link_args=link_args,
+            include_dirs=[np.get_include()],
+            define_macros=[('CYTHON_TRACE', '1')],
+            language='c'),
+    Extension("arcticpy.main_utils", ["arcticpy/main_utils.pyx"],
+            extra_compile_args=link_args,
+            extra_link_args=link_args,
+            include_dirs=[np.get_include()],
+            define_macros=[('CYTHON_TRACE', '1')],
+            language='c'),
+]
+ext_modules = cythonize(
+    ext_modules, compiler_directives={'language_level': 3})
 
 setuptools.setup(
     name="arcticpy",
@@ -25,4 +52,5 @@ setuptools.setup(
     python_requires=">=3",
     install_requires=requirements,
     keywords=["charge transfer inefficiency correction"],
+    ext_modules=ext_modules,
 )


### PR DESCRIPTION
Hi all,

I just thought I'd share some of the code changes I have made and the impact they've had.

# TLDR
I have managed to achieve about a **factor of 2** speed up on the simple example Jacob shared with me, `test_arcticpy/profile_demo.py`

On my local machine this problem outputs:

```
express = 5
output_name = "test_5"
do_plot = False
2067 row(s), 10 column(s)

         21243410 function calls (19635936 primitive calls) in 32.943 seconds
```

as opposed to `28045046 function calls (26951282 primitive calls) in 61.871 seconds` on the `dev` branch. I've also added a local (uncommitted) check which ensures the output remains identical.

# What did I change?

The largest performance increase actually came from partial cythonizing of `clock_charge_in_one_direction`. A simple line profiler suggested that this function was wasting a lot of time doing simple loops. 

I also got performance gains from the following methods
`n_trapped_electrons_from_watermarks`
`update_watermark_volumes_for_cloud_below_highest` (particularly removing the `np.roll`)
and cythonizing a small part of `watermark_index_above_cloud_from_cloud_fractional_volume`

I also found some code like the following, 
`if a not in np.cumsum(an_array)`

This particularly line was wasting quite a lot of time. I wrote a small cython function which achieves the same result and can be used as follows,

`if not  cy_value_in_cumsum(a, an_array)`

This is entirely C, and doesn't require any array allocations.



